### PR TITLE
Add Internal NodeIP -> External IP mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,7 @@ $(BIN): $(SOURCES)
 
 install: $(BIN)
 	mkdir -p ~/.packer.d/plugins/
-	mkdir -p /usr/local/bin/github.com/macstadium/macstadium-orka/
 	cp $(BIN) ~/.packer.d/plugins/
-	cp $(BIN) /usr/local/bin/github.com/macstadium/macstadium-orka/$(BIN)_v2.3.0_x5.0_darwin_amd64
 
 packer-build-example:
 	PACKER_LOG=1 packer build -on-error=ask examples/orka.pkr.hcl

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ $(BIN): $(SOURCES)
 
 install: $(BIN)
 	mkdir -p ~/.packer.d/plugins/
-	mv $(BIN) ~/.packer.d/plugins/
+	mkdir -p /usr/local/bin/github.com/macstadium/macstadium-orka/
+	cp $(BIN) ~/.packer.d/plugins/
+	cp $(BIN) /usr/local/bin/github.com/macstadium/macstadium-orka/$(BIN)_v2.3.0_x5.0_darwin_amd64
 
 packer-build-example:
 	PACKER_LOG=1 packer build -on-error=ask examples/orka.pkr.hcl

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(BIN): $(SOURCES)
 
 install: $(BIN)
 	mkdir -p ~/.packer.d/plugins/
-	cp $(BIN) ~/.packer.d/plugins/
+	mv $(BIN) ~/.packer.d/plugins/
 
 packer-build-example:
 	PACKER_LOG=1 packer build -on-error=ask examples/orka.pkr.hcl

--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
-	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
@@ -47,8 +47,8 @@ type Config struct {
 	// have ran. This moves the copy logic up-front but also consumes more disk space
 	// while the build is running. This was done as a workaround in Orka since the save
 	// API method did not actually copy over the base image contents.
-	ImagePrecopy bool `mapstructure:"image_precopy" required:"false"`
-	Mock	MockOptions `mapstructure:"mock" required:"false"`
+	ImagePrecopy bool        `mapstructure:"image_precopy" required:"false"`
+	Mock         MockOptions `mapstructure:"mock" required:"false"`
 
 	// Do not image after completion, for some manual testing, for internal dev/testing.
 	NoCreateImage bool `mapstructure:"no_create_image"`
@@ -58,6 +58,12 @@ type Config struct {
 
 	// Enable Boost IO Performance https://orkadocs.macstadium.com/docs/boost-io-performance
 	OrkaVMBuilderEnableIOBoost bool `mapstructure:"orka_enable_io_boost"`
+
+	// Enable Orka IP Mapping for exposed IP networking
+	EnableOrkaNodeIPMapping bool `mapstructure:"enable_orka_node_ip_mapping"`
+
+	// Required if Enable Orka IP Mapping is enabled. Map of Node Ips to the external IP values.
+	OrkaNodeIPMap map[string]string `mapstructure:"orka_node_ip_map"`
 }
 
 type MockOptions struct {

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -81,6 +81,8 @@ type FlatConfig struct {
 	NoCreateImage              *bool             `mapstructure:"no_create_image" cty:"no_create_image" hcl:"no_create_image"`
 	NoDeleteVM                 *bool             `mapstructure:"no_delete_vm" cty:"no_delete_vm" hcl:"no_delete_vm"`
 	OrkaVMBuilderEnableIOBoost *bool             `mapstructure:"orka_enable_io_boost" cty:"orka_enable_io_boost" hcl:"orka_enable_io_boost"`
+	EnableOrkaNodeIPMapping    *bool             `mapstructure:"enable_orka_node_ip_mapping" cty:"enable_orka_node_ip_mapping" hcl:"enable_orka_node_ip_mapping"`
+	OrkaNodeIPMap              map[string]string `mapstructure:"orka_node_ip_map" cty:"orka_node_ip_map" hcl:"orka_node_ip_map"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -166,6 +168,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"no_create_image":              &hcldec.AttrSpec{Name: "no_create_image", Type: cty.Bool, Required: false},
 		"no_delete_vm":                 &hcldec.AttrSpec{Name: "no_delete_vm", Type: cty.Bool, Required: false},
 		"orka_enable_io_boost":         &hcldec.AttrSpec{Name: "orka_enable_io_boost", Type: cty.Bool, Required: false},
+		"enable_orka_node_ip_mapping":  &hcldec.AttrSpec{Name: "enable_orka_node_ip_mapping", Type: cty.Bool, Required: false},
+		"orka_node_ip_map":             &hcldec.AttrSpec{Name: "orka_node_ip_map", Type: cty.Map(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -234,7 +234,10 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 		sshHost = config.OrkaNodeIPMap[vmDeployResponseData.IP]
 
 		if sshHost == "" {
-			panic(fmt.Sprintf("VM IP[%s] is not tracked in the provided node ip map. Please provide a mapping for this VM!", vmDeployResponseData.IP))
+			e := fmt.Errorf("VM IP[%s] is not tracked in the provided node ip map. Please provide a mapping for this VM!", vmDeployResponseData.IP)
+			ui.Error(e.Error())
+			state.Put("error", e)
+			return multistep.ActionHalt
 		}
 
 		ui.Say(fmt.Sprintf("Found Internal VM IP in map [%s -> %s]", vmDeployResponseData.IP, sshHost))

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -63,7 +63,6 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 	// # ORKA API LOGIN FOR TOKEN #
 	// ############################
 	ui.Say("Logging into Orka API endpoint")
-
 	token, err := s.createOrkaToken(state)
 
 	if err != nil {
@@ -228,15 +227,26 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 	state.Put("vmid", vmDeployResponseData.VMId)
 
 	ui.Say(fmt.Sprintf("Created VM [%s]", vmDeployResponseData.VMId))
+
+	sshHost := vmDeployResponseData.IP
+
+	if config.EnableOrkaNodeIPMapping == true {
+		sshHost = config.OrkaNodeIPMap[vmDeployResponseData.IP]
+
+		if sshHost == "" {
+			panic(fmt.Sprintf("VM IP[%s] is not tracked in the provided node ip map. Please provide a mapping for this VM!", vmDeployResponseData.IP))
+		}
+
+		ui.Say(fmt.Sprintf("Found Internal VM IP in map [%s -> %s]", vmDeployResponseData.IP, sshHost))
+	}
+
 	ui.Say(fmt.Sprintf("SSH server will be available at [%s:%s]",
-		vmDeployResponseData.IP, vmDeployResponseData.SSHPort))
+		sshHost, vmDeployResponseData.SSHPort))
 
 	// Write to our state databag for pick-up by the ssh communicator.
-
 	sshPort, _ := strconv.Atoi(vmDeployResponseData.SSHPort)
-
 	state.Put("ssh_port", sshPort)
-	state.Put("ssh_host", vmDeployResponseData.IP)
+	state.Put("ssh_host", sshHost)
 
 	// Continue processing
 	return multistep.ActionContinue
@@ -329,7 +339,6 @@ func (s *stepOrkaCreate) Cleanup(state multistep.StateBag) {
 		fmt.Sprintf("%s/%s", config.OrkaEndpoint, "resources/vm/purge"),
 		bytes.NewBuffer(vmPurgeRequestDatJSON),
 	)
-
 
 	vmPurgeRequest.Header.Set("Content-Type", "application/json")
 	vmPurgeRequest.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -93,6 +93,13 @@ But, if you are building/editing/updating this software, you may want to turn on
 
 * `do_not_image` _(boolean)_ (optional) _*- for devs*_ By default this plugin automatically creates an image of the VM after any provisioning steps.  This is useful for debugging builds.   
 
+# Advanced Use Cases
+
+The following use cases do not need to be used in most scenarios.
+
+* `enable_orka_node_ip_mapping` _(bool)_ (optional): The plugin defaults to using the default node ips. If this option is set to true, the builder will use the passed in map under `orka_node_ip_map` to resolve ips.
+
+* `orka_node_ip_map` _(map[string]string)_ (optional): Required if `enable_orka_node_ip_mapping`. Map of Internal Node IPs to External Node Ips.
 
 # Information Notes / Gotchas
 


### PR DESCRIPTION
Currently the Orka API only returns internal NodeIPs for the orka cluster. This becomes an issue when attempting to run packer jobs when not connected to a jumpbox / vpn, as the packer plugin will be unable to publish images.

This MR adds the ability to provide an optional map to the plugin configuration to override the default returned internal ip address with its external ip.