### PR TITLE
Update plugin release procedure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.16
       - name: Describe plugin
@@ -34,10 +34,10 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5.0.0
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.NEW_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.NEW_PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,19 +9,14 @@ before:
     - go test ./...
     # As part of the release doc files are included as a separate deliverable for
     # consumption by Packer.io. To include a separate docs.zip uncomment the following command.
-    #- /bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
+    #- make ci-release-docs
+    # Check plugin compatibility with required version of the Packer SDK
+    - make plugin-check
 builds:
   # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
   -
     id: plugin-check
     mod_timestamp: '{{ .CommitTimestamp }}'
-    hooks:
-      post:
-        # This will check plugin compatibility against latest version of Packer
-        - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
-            packer-plugins-check -load={{ .Name }}
-          dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
@@ -48,6 +43,8 @@ builds:
       - arm
       - arm64
     ignore:
+      - goos: windows
+        goarch: arm64
       - goos: darwin
         goarch: '386'
       - goos: linux

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX := github.com/macstadium/packer-plugin-macstadium-orka
 VERSION := $(shell git describe --tags --candidates=1 --dirty 2>/dev/null || echo "dev")
-FLAGS := -X main.Version=$(VERSION)
+FLAGS := -X version/version.Version=$(VERSION)
 BIN := packer-plugin-macstadium-orka
 SOURCES := $(shell find . -name '*.go')
 GOOS ?= darwin
@@ -26,6 +26,9 @@ packer-build-example:
 
 packer-build-example-non-debug:
 	packer build examples/orka.pkr.hcl
+
+plugin-check: build
+	PATH=$(shell pwd):${PATH} packer-sdc plugin-check $(BIN)
 
 fresh: clean build install packer-build-example-non-debug clean
 

--- a/main.go
+++ b/main.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
 	"github.com/macstadium/packer-plugin-macstadium-orka/builder/orka"
+	builderVersion "github.com/macstadium/packer-plugin-macstadium-orka/version"
 )
 
 func main() {
 	pps := plugin.NewSet()
 	pps.RegisterBuilder(plugin.DEFAULT_NAME, new(orka.Builder))
+	pps.SetVersion(builderVersion.PluginVersion)
 	err := pps.Run()
 
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,19 @@
+package version
+
+import (
+	"github.com/hashicorp/packer-plugin-sdk/version"
+)
+
+var (
+	// Version is the main version number that is being run at the moment.
+	Version = "0.0.1"
+
+	// VersionPrerelease is A pre-release marker for the Version. If this is ""
+	// (empty string) then it means that it is a final release. Otherwise, this
+	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = "dev"
+
+	// PluginVersion is used by the plugin set to allow Packer to recognize
+	// what version this plugin is.
+	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+)


### PR DESCRIPTION
Update tooling
Update GPG key as the old one no longer works
Allow the workflow to be run manually for testing