### PR TITLE
OK-1526 Set `io_boost` to `true` if not provided

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -57,7 +57,7 @@ type Config struct {
 	NoDeleteVM bool `mapstructure:"no_delete_vm"`
 
 	// Enable Boost IO Performance https://orkadocs.macstadium.com/docs/boost-io-performance
-	OrkaVMBuilderEnableIOBoost bool `mapstructure:"orka_enable_io_boost"`
+	OrkaVMBuilderEnableIOBoost *bool `mapstructure:"orka_enable_io_boost"`
 
 	// Enable Orka IP Mapping for exposed IP networking
 	EnableOrkaNodeIPMapping bool `mapstructure:"enable_orka_node_ip_mapping"`
@@ -137,6 +137,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	// If we didn't specify the number of cores, set it to the default of 3.
 	if c.OrkaVMCPUCore == 0 {
 		c.OrkaVMCPUCore = 3
+	}
+
+	if c.OrkaVMBuilderEnableIOBoost == nil {
+		var defaultIOBoostValue = true
+		c.OrkaVMBuilderEnableIOBoost = &defaultIOBoostValue
 	}
 
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -155,7 +155,7 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 		OrkaImage:         config.OrkaVMBuilderName,
 		OrkaCPUCore:       config.OrkaVMCPUCore,
 		VCPUCount:         config.OrkaVMCPUCore,
-		OrkaEnableIOBoost: config.OrkaVMBuilderEnableIOBoost,
+		OrkaEnableIOBoost: *config.OrkaVMBuilderEnableIOBoost,
 	}
 	vmCreateConfigRequestDataJSON, _ := json.Marshal(vmCreateConfigRequestData)
 	vmCreateConfigRequest, _ := http.NewRequest(

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -77,7 +77,7 @@ build {
 
 * `orka_vm_builder_prefix` _(string)_ (optional): If orka_vm_builder_name is not passed in, you can add prefix to the virtual machine name that the plugin appends a timestamp to. Defaults to packer.
 
-* `orka_enable_io_boost` _(bool)_ (optional): Enable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), off by default  
+- `orka_enable_io_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), on by default
 
 * `orka_vm_cpu_core` _(int)_ (optional):  Number of cpu cores to use with the virtual machine.  
 


### PR DESCRIPTION
This PR sets `io_boost` to `true` if not explicitly provided in the packer configuration.