### PR TITLE
cf/vm-tagging

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	OrkaVMBuilderPrefix string `mapstructure:"orka_vm_builder_prefix"`
 	OrkaVMBuilderName   string `mapstructure:"orka_vm_builder_name"`
 	OrkaVMCPUCore       int    `mapstructure:"orka_vm_cpu_core"`
+	OrkaVMTag           string `mapstructure:"orka_vm_tag"`
 
 	// Name of the VM Config to launch from
 	SourceImage string `mapstructure:"source_image" required:"true"`

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -73,6 +73,7 @@ type FlatConfig struct {
 	OrkaVMBuilderPrefix        *string           `mapstructure:"orka_vm_builder_prefix" cty:"orka_vm_builder_prefix" hcl:"orka_vm_builder_prefix"`
 	OrkaVMBuilderName          *string           `mapstructure:"orka_vm_builder_name" cty:"orka_vm_builder_name" hcl:"orka_vm_builder_name"`
 	OrkaVMCPUCore              *int              `mapstructure:"orka_vm_cpu_core" cty:"orka_vm_cpu_core" hcl:"orka_vm_cpu_core"`
+	OrkaVMTag                  *string           `mapstructure:"orka_vm_tag" cty:"orka_vm_tag" hcl:"orka_vm_tag"`
 	SourceImage                *string           `mapstructure:"source_image" required:"true" cty:"source_image" hcl:"source_image"`
 	ImageName                  *string           `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	SimulateCreate             *bool             `mapstructure:"simulate_create" cty:"simulate_create" hcl:"simulate_create"`
@@ -160,6 +161,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"orka_vm_builder_prefix":       &hcldec.AttrSpec{Name: "orka_vm_builder_prefix", Type: cty.String, Required: false},
 		"orka_vm_builder_name":         &hcldec.AttrSpec{Name: "orka_vm_builder_name", Type: cty.String, Required: false},
 		"orka_vm_cpu_core":             &hcldec.AttrSpec{Name: "orka_vm_cpu_core", Type: cty.Number, Required: false},
+		"orka_vm_tag":                  &hcldec.AttrSpec{Name: "orka_vm_tag", Type: cty.String, Required: false},
 		"source_image":                 &hcldec.AttrSpec{Name: "source_image", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"simulate_create":              &hcldec.AttrSpec{Name: "simulate_create", Type: cty.Bool, Required: false},

--- a/builder/orka/main.go
+++ b/builder/orka/main.go
@@ -40,6 +40,7 @@ type VMCreateRequest struct {
 	OrkaCPUCore       int    `json:"orka_cpu_core"`
 	VCPUCount         int    `json:"vcpu_count"`
 	OrkaEnableIOBoost bool   `json:"io_boost"`
+	OrkaVMTag         string `json:"orka_vm_tag"`
 }
 
 type VMCreateResponse struct {

--- a/builder/orka/main.go
+++ b/builder/orka/main.go
@@ -40,7 +40,7 @@ type VMCreateRequest struct {
 	OrkaCPUCore       int    `json:"orka_cpu_core"`
 	VCPUCount         int    `json:"vcpu_count"`
 	OrkaEnableIOBoost bool   `json:"io_boost"`
-	OrkaVMTag         string `json:"orka_vm_tag"`
+	OrkaVMTag         string `json:"tag"`
 }
 
 type VMCreateResponse struct {

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -155,6 +155,7 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 		OrkaCPUCore:       config.OrkaVMCPUCore,
 		VCPUCount:         config.OrkaVMCPUCore,
 		OrkaEnableIOBoost: config.OrkaVMBuilderEnableIOBoost,
+		OrkaVMTag:         config.OrkaVMTag,
 	}
 	vmCreateConfigRequestDataJSON, _ := json.Marshal(vmCreateConfigRequestData)
 	vmCreateConfigRequest, err := http.NewRequest(

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -155,7 +155,7 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 		OrkaImage:         config.OrkaVMBuilderName,
 		OrkaCPUCore:       config.OrkaVMCPUCore,
 		VCPUCount:         config.OrkaVMCPUCore,
-    OrkaEnableIOBoost: *config.OrkaVMBuilderEnableIOBoost,
+    		OrkaEnableIOBoost: *config.OrkaVMBuilderEnableIOBoost,
 		OrkaVMTag:         config.OrkaVMTag,
 	}
 	vmCreateConfigRequestDataJSON, _ := json.Marshal(vmCreateConfigRequestData)

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -81,6 +81,8 @@ build {
 
 * `orka_vm_cpu_core` _(int)_ (optional):  Number of cpu cores to use with the virtual machine.  
 
+* `orka_vm_tag` _(string)_ (optional): Image tag name for the builder VM
+
 * `image_precopy` _(bool)_ (optional): The plugin defaults to using image save.  If this option is set to true, the builder will commit the image and perform an image copy. 
 
 # Development / Internal Variables


### PR DESCRIPTION
This change allows for VMs deployed by packer to be tagged using the VM tagging feature. 

This will allow customers creating large images on Apple Silicon to ensure that VMs are launched on the same node each time. This will cut down on caching times for image builds that require multiple stages of packer scripts. 