### PR TITLE
Fix `PATH` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: $(BIN)
 
 $(BIN): $(SOURCES)
 	GOBIN=$(shell pwd) go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest
-	PATH=$(shell pwd):${PATH} go generate builder/orka/config.go
+	PATH="$(shell pwd):${PATH}" go generate builder/orka/config.go
 	go build -ldflags="$(FLAGS)" -o $(BIN) $(PREFIX)
 
 install: $(BIN)


### PR DESCRIPTION
Currently, the `make build` command may fail if there are spaces in the system path variable. Example:

```sh
➜  packer-plugin-macstadium-orka git:(main) ✗ make build                                                                            <aws:dev>
GOBIN=/Users/spikeburton/Development/code/packer-plugin-macstadium-orka go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@latest
PATH=/Users/spikeburton/Development/code/packer-plugin-macstadium-orka:/Users/spikeburton/.nvm/versions/node/v16.15.0/bin:/Users/spikeburton/.asdf/shims:/opt/homebrew/opt/asdf/libexec/bin:/opt/homebrew/Cellar/pyenv-virtualenv/1.2.1/shims:/Users/spikeburton/.pyenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion Tech Preview.app/Contents/Public:/Library/Apple/usr/bin:/Applications/Wireshark.app/Contents/MacOS:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/spikeburton/go/bin go generate builder/orka/config.go
/bin/sh: Fusion: command not found
make: *** [packer-plugin-macstadium-orka] Error 127
```

Quote `PATH` to preserve the whitespace.