### PR TITLE
Enhance Logging and deprecate ioutil.ReadAll

### DIFF
--- a/builder/orka/builder_acc_test.go
+++ b/builder/orka/builder_acc_test.go
@@ -3,7 +3,7 @@ package orka
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"testing"
@@ -95,7 +95,7 @@ func TestSuccessfulOrkaBuilder(t *testing.T) {
 
 			defer logs.Close()
 
-			logsBytes, err := ioutil.ReadAll(logs)
+			logsBytes, err := io.ReadAll(logs)
 			assert.Nil(t, err)
 			logsString := string(logsBytes)
 
@@ -129,7 +129,7 @@ func TestFailedOrkaBuilder(t *testing.T) {
 
 				defer logs.Close()
 
-				logsBytes, err := ioutil.ReadAll(logs)
+				logsBytes, err := io.ReadAll(logs)
 				assert.Nil(t, err)
 				logsString := string(logsBytes)
 

--- a/builder/orka/builder_acc_test.go
+++ b/builder/orka/builder_acc_test.go
@@ -41,8 +41,7 @@ var ErrorTypes = map[string]string{
 }
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {
-	var raw interface{}
-	raw = &Builder{}
+	var raw interface{} = &Builder{}
 	if _, ok := raw.(packer.Builder); !ok {
 		t.Fatalf("Builder should be a builder")
 	}

--- a/builder/orka/builder_acc_test.go
+++ b/builder/orka/builder_acc_test.go
@@ -37,6 +37,7 @@ var ErrorTypes = map[string]string{
 	"ImageSave":   "false",
 	"ImageCopy":   "true",
 	"ImageCommit": "true",
+	"HealthCheck": "false",
 }
 
 func TestBuilder_ImplementsBuilder(t *testing.T) {

--- a/builder/orka/main.go
+++ b/builder/orka/main.go
@@ -30,7 +30,8 @@ type ImageDeleteRequest struct {
 }
 
 type ImageDeleteResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMCreateRequest struct {
@@ -53,9 +54,10 @@ type VMDeployRequest struct {
 }
 
 type VMDeployResponse struct {
-	VMId    string `json:"vm_id"`
-	IP      string `json:"ip"`
-	SSHPort string `json:"ssh_port"`
+	VMId    string               `json:"vm_id"`
+	IP      string               `json:"ip"`
+	SSHPort string               `json:"ssh_port"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMPurgeRequest struct {
@@ -67,7 +69,8 @@ type ImageCommitRequest struct {
 }
 
 type ImageCommitResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type ImageSaveRequest struct {
@@ -76,7 +79,8 @@ type ImageSaveRequest struct {
 }
 
 type ImageSaveResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMStartRequest struct {
@@ -84,7 +88,8 @@ type VMStartRequest struct {
 }
 
 type VMStartResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMStopRequest struct {
@@ -92,11 +97,13 @@ type VMStopRequest struct {
 }
 
 type VMStopResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type HealthCheckResponse struct {
-	Version string `json:"api_version"`
+	Version string               `json:"api_version"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 const OrkaAPIRequestErrorMessage = "Error making request to Orka API"

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -46,7 +46,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 
 		imageCommitRequestData := ImageCommitRequest{vmid}
 		imageCommitRequestDataJSON, _ := json.Marshal(imageCommitRequestData)
-		imageCommitRequest, err := http.NewRequestWithContext(
+		imageCommitRequest, _ := http.NewRequestWithContext(
 			ctx,
 			http.MethodPost,
 			fmt.Sprintf("%s/%s", config.OrkaEndpoint, "resources/image/commit"),
@@ -60,7 +60,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 			s.failedCommit = true
 			e := fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err)
 			ui.Error(e.Error())
-			state.Put("error", err)
+			state.Put("error", e)
 			return multistep.ActionHalt
 		}
 
@@ -73,7 +73,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 			s.failedCommit = true
 			e := fmt.Errorf("Error committing image [%s]", imageCommitResponse.Status)
 			ui.Error(e.Error())
-			state.Put("error", err)
+			state.Put("error", e)
 			return multistep.ActionHalt
 		}
 
@@ -87,7 +87,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 
 		imageSaveRequestData := ImageSaveRequest{vmid, config.ImageName}
 		imageSaveRequestDataJSON, _ := json.Marshal(imageSaveRequestData)
-		imageSaveRequest, err := http.NewRequestWithContext(
+		imageSaveRequest, _ := http.NewRequestWithContext(
 			ctx,
 			http.MethodPost,
 			fmt.Sprintf("%s/%s", config.OrkaEndpoint, "resources/image/save"),
@@ -101,7 +101,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 			s.failedSave = true
 			e := fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err)
 			ui.Error(e.Error())
-			state.Put("error", err)
+			state.Put("error", e)
 			return multistep.ActionHalt
 		}
 
@@ -114,7 +114,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 			s.failedSave = true
 			e := fmt.Errorf("%s [%s]", OrkaAPIResponseErrorMessage, imageSaveResponse.Status)
 			ui.Error(e.Error())
-			state.Put("error", err)
+			state.Put("error", e)
 			return multistep.ActionHalt
 		}
 

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -51,7 +51,7 @@ func (s *stepOrkaCreate) createOrkaToken(state multistep.StateBag) (string, erro
 	}
 
 	var respData TokenLoginResponse
-	respBodyBytes, _ := ioutil.ReadAll(resp.Body)
+	respBodyBytes, _ := io.ReadAll(resp.Body)
 	json.Unmarshal(respBodyBytes, &respData)
 
 	return respData.Token, nil
@@ -119,7 +119,7 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 			defer imageCopyResponse.Body.Close()
 
 			var imageCopyResponseData ImageCopyResponse
-			imageCopyResponseBytes, _ := ioutil.ReadAll(imageCopyResponse.Body)
+			imageCopyResponseBytes, _ := io.ReadAll(imageCopyResponse.Body)
 			json.Unmarshal(imageCopyResponseBytes, &imageCopyResponseData)
 
 			if imageCopyResponse.StatusCode != http.StatusOK {
@@ -178,7 +178,7 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 	defer vmCreateConfigResponse.Body.Close()
 
 	var vmCreateConfigResponseData VMCreateResponse
-	vmCreateConfigResponseBytes, _ := ioutil.ReadAll(vmCreateConfigResponse.Body)
+	vmCreateConfigResponseBytes, _ := io.ReadAll(vmCreateConfigResponse.Body)
 	json.Unmarshal(vmCreateConfigResponseBytes, &vmCreateConfigResponseData)
 
 	if vmCreateConfigResponse.StatusCode != http.StatusCreated {
@@ -218,7 +218,7 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 
 	defer vmDeployResponse.Body.Close()
 	var vmDeployResponseData VMDeployResponse
-	vmDeployResponseBodyBytes, _ := ioutil.ReadAll(vmDeployResponse.Body)
+	vmDeployResponseBodyBytes, _ := io.ReadAll(vmDeployResponse.Body)
 	json.Unmarshal(vmDeployResponseBodyBytes, &vmDeployResponseData)
 
 	if vmDeployResponse.StatusCode != http.StatusOK {
@@ -399,7 +399,7 @@ func (s *stepOrkaCreate) Cleanup(state multistep.StateBag) {
 	}
 
 	var healthCheckResponseData HealthCheckResponse
-	healthCheckResponseBodyBytes, _ := ioutil.ReadAll(healthCheckResponse.Body)
+	healthCheckResponseBodyBytes, _ := io.ReadAll(healthCheckResponse.Body)
 	json.Unmarshal(healthCheckResponseBodyBytes, &healthCheckResponseData)
 
 	serverVersion, _ := version.NewVersion(healthCheckResponseData.Version)

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -403,6 +403,8 @@ func (s *stepOrkaCreate) Cleanup(state multistep.StateBag) {
 	json.Unmarshal(healthCheckResponseBodyBytes, &healthCheckResponseData)
 
 	serverVersion, _ := version.NewVersion(healthCheckResponseData.Version)
+
+	// Orka Version where the token system moved from multi to single token architechture
 	singleTokenVersion, _ := version.NewVersion("2.1.1")
 
 	if serverVersion.LessThanOrEqual(singleTokenVersion) {

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -300,7 +300,6 @@ func (s *stepOrkaCreate) precopyImageDelete(state multistep.StateBag) error {
 	}
 
 	ui.Say(fmt.Sprintf("Image deleted [%s]", imageDeleteResponse.Status))
-	imageDeleteResponse.Body.Close()
 
 	return nil
 }

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -13,6 +13,7 @@ import (
 /***************************************************
 *	/token  			POST	   *
 *	/token  			DELETE     *
+*   /health-check       GET        *
 *	/resources/image/copy  		POST       *
 *	/resources/image/commit  	POST	   *
 *	/resources/image/save  		POST       *

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -95,7 +95,9 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		if c.ErrorType == "HealthCheck" {
 			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
-		json := `{"api_version":"2.4.0"}`
+		json := `{
+			"api_version": "2.0.0"
+		}`
 		return Response(req, json, http.StatusOK, "200 OK")
 
 	}

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -2,14 +2,14 @@ package mocks
 
 import (
 	"bytes"
-	"net/http"
 	"io/ioutil"
+	"net/http"
 	"time"
 )
 
-	// ############################
-	// # 	    ENDPOINTS         #
-	// ############################
+// ############################
+// # 	    ENDPOINTS         #
+// ############################
 /***************************************************
 *	/token  			POST	   *
 *	/token  			DELETE     *
@@ -22,75 +22,81 @@ import (
 *	/resources/vm/purge  		DELETE     *
 ****************************************************/
 
-
 type Client struct {
 	ErrorType string
-	Timeout time.Duration
+	Timeout   time.Duration
 }
 
 // Do is the moc client's 'Do' func
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	Request := req.URL.Path + ":" + req.Method
 	jsonError := `{"message":"", "errors": [{"message": "Error"}]}`
-	switch Request { 
+	switch Request {
 	case "/token:POST":
 		if c.ErrorType == "Login" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"token":"sometoken","message":"success", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/token:DELETE":
 		if c.ErrorType == "Logout" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"tokensRevoked":"1","message":"", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/resources/image/copy:POST":
 		if c.ErrorType == "ImageCopy" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"message":"Successfully copied", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/resources/image/delete:DELETE":
 		if c.ErrorType == "ImageDelete" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"message":"Successfully deleted", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/resources/image/commit:POST":
 		if c.ErrorType == "ImageCommit" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"message":"committed", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/resources/image/save:POST":
 		if c.ErrorType == "ImageSave" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"message":"saved", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/resources/vm/create:POST":
 		if c.ErrorType == "VMCreate" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"message":"Successfully Created", "errors": []}`
-		return Response(req, json, 201, "201 Created")
+		return Response(req, json, http.StatusCreated, "201 Created")
 	case "/resources/vm/deploy:POST":
 		if c.ErrorType == "VMDeploy" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{
 			"vm_id": "05ca969973999",
 			"ip": "10.221.188.11",
 			"ssh_port": "8823"
 		}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
 	case "/resources/vm/purge:DELETE":
 		if c.ErrorType == "VMPurge" {
-			return Response(req, jsonError, 500, "500 Internal Server Error")
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
 		json := `{"message":"Successfully purged VM", "errors": []}`
-		return Response(req, json, 200, "200 OK")
+		return Response(req, json, http.StatusOK, "200 OK")
+	case "/health-check":
+		if c.ErrorType == "HealthCheck" {
+			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
+		}
+		json := `{"message":"Cluster Healthy", "errors": []}`
+		return Response(req, json, http.StatusOK, "200 OK")
+
 	}
 	return nil, nil
 }
@@ -100,7 +106,7 @@ func Response(req *http.Request, json string, StatusCode int, Status string) (*h
 	r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
 	return &http.Response{
 		StatusCode: StatusCode,
-		Status: Status,
+		Status:     Status,
 		Body:       r,
 	}, nil
 }

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -11,9 +11,9 @@ import (
 // # 	    ENDPOINTS         #
 // ############################
 /***************************************************
-*	/token  			POST	   *
-*	/token  			DELETE     *
-*   /health-check       GET        *
+*	/token  					POST	   *
+*	/token  		         	DELETE     *
+*   /health-check               GET        *
 *	/resources/image/copy  		POST       *
 *	/resources/image/commit  	POST	   *
 *	/resources/image/save  		POST       *

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -90,11 +90,11 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		}
 		json := `{"message":"Successfully purged VM", "errors": []}`
 		return Response(req, json, http.StatusOK, "200 OK")
-	case "/health-check":
+	case "/health-check:GET":
 		if c.ErrorType == "HealthCheck" {
 			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
-		json := `{"api_version":"2.4.0", "errors": []}`
+		json := `{"api_version":"2.4.0"}`
 		return Response(req, json, http.StatusOK, "200 OK")
 
 	}

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -94,7 +94,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		if c.ErrorType == "HealthCheck" {
 			return Response(req, jsonError, http.StatusInternalServerError, "500 Internal Server Error")
 		}
-		json := `{"message":"Cluster Healthy", "errors": []}`
+		json := `{"api_version":"2.4.0", "errors": []}`
 		return Response(req, json, http.StatusOK, "200 OK")
 
 	}


### PR DESCRIPTION
This pull request depreciates `ioutil.ReadAll` for `io.ReadAll` and enhances logging in the to push errors from an orka cluster through to the packer ui