### PR TITLE
Enhance logging and depricate ioutil.ReadAll

### DIFF
--- a/builder/orka/builder_acc_test.go
+++ b/builder/orka/builder_acc_test.go
@@ -3,7 +3,7 @@ package orka
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"testing"
@@ -95,7 +95,7 @@ func TestSuccessfulOrkaBuilder(t *testing.T) {
 
 			defer logs.Close()
 
-			logsBytes, err := ioutil.ReadAll(logs)
+			logsBytes, err := io.ReadAll(logs)
 			assert.Nil(t, err)
 			logsString := string(logsBytes)
 
@@ -129,7 +129,7 @@ func TestFailedOrkaBuilder(t *testing.T) {
 
 				defer logs.Close()
 
-				logsBytes, err := ioutil.ReadAll(logs)
+				logsBytes, err := io.ReadAll(logs)
 				assert.Nil(t, err)
 				logsString := string(logsBytes)
 

--- a/builder/orka/main.go
+++ b/builder/orka/main.go
@@ -30,7 +30,8 @@ type ImageDeleteRequest struct {
 }
 
 type ImageDeleteResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMCreateRequest struct {
@@ -53,9 +54,10 @@ type VMDeployRequest struct {
 }
 
 type VMDeployResponse struct {
-	VMId    string `json:"vm_id"`
-	IP      string `json:"ip"`
-	SSHPort string `json:"ssh_port"`
+	VMId    string               `json:"vm_id"`
+	IP      string               `json:"ip"`
+	SSHPort string               `json:"ssh_port"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMPurgeRequest struct {
@@ -67,7 +69,8 @@ type ImageCommitRequest struct {
 }
 
 type ImageCommitResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type ImageSaveRequest struct {
@@ -76,7 +79,8 @@ type ImageSaveRequest struct {
 }
 
 type ImageSaveResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMStartRequest struct {
@@ -84,7 +88,8 @@ type VMStartRequest struct {
 }
 
 type VMStartResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type VMStopRequest struct {
@@ -92,11 +97,13 @@ type VMStopRequest struct {
 }
 
 type VMStopResponse struct {
-	Message string `json:"message"`
+	Message string               `json:"message"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 type HealthCheckResponse struct {
-	Version string `json:"api_version"`
+	Version string               `json:"api_version"`
+	Errors  []OrkaResponseErrors `json:"errors"`
 }
 
 const OrkaAPIRequestErrorMessage = "Error making request to Orka API"

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -45,14 +45,14 @@ func (s *stepOrkaCreate) createOrkaToken(state multistep.StateBag) (string, erro
 
 	defer resp.Body.Close()
 
+	var respData TokenLoginResponse
+	respBodyBytes, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(respBodyBytes, &respData)
+
 	if resp.StatusCode != http.StatusOK {
-		e := fmt.Errorf("%s", resp.Status)
+		e := fmt.Errorf("%s - %s", resp.Status, respData.Errors[0].Message)
 		return "", e
 	}
-
-	var respData TokenLoginResponse
-	respBodyBytes, _ := ioutil.ReadAll(resp.Body)
-	json.Unmarshal(respBodyBytes, &respData)
 
 	return respData.Token, nil
 }
@@ -109,7 +109,8 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 			imageCopyResponse, err := client.Do(imageCopyRequest)
 
 			if err != nil {
-				ui.Error(fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err).Error())
+				e := fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err)
+				ui.Error(e.Error())
 				state.Put("error", err)
 				s.createVMFailed = true
 				s.precopyFailed = true
@@ -119,12 +120,13 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 			defer imageCopyResponse.Body.Close()
 
 			var imageCopyResponseData ImageCopyResponse
-			imageCopyResponseBytes, _ := ioutil.ReadAll(imageCopyResponse.Body)
+			imageCopyResponseBytes, _ := io.ReadAll(imageCopyResponse.Body)
 			json.Unmarshal(imageCopyResponseBytes, &imageCopyResponseData)
 
 			if imageCopyResponse.StatusCode != http.StatusOK {
 				e := fmt.Errorf("Error from API: %s", imageCopyResponse.Status)
 				ui.Error(e.Error())
+				ui.Error(imageCopyResponseData.Errors[0].Message)
 				state.Put("error", e)
 				s.createVMFailed = true
 				return multistep.ActionHalt
@@ -171,19 +173,21 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 	vmCreateConfigResponse, err := client.Do(vmCreateConfigRequest)
 
 	if err != nil {
-		ui.Error(fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err).Error())
+		e := fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err)
+		ui.Error(e.Error())
 		return multistep.ActionHalt
 	}
 
 	defer vmCreateConfigResponse.Body.Close()
 
 	var vmCreateConfigResponseData VMCreateResponse
-	vmCreateConfigResponseBytes, _ := ioutil.ReadAll(vmCreateConfigResponse.Body)
+	vmCreateConfigResponseBytes, _ := io.ReadAll(vmCreateConfigResponse.Body)
 	json.Unmarshal(vmCreateConfigResponseBytes, &vmCreateConfigResponseData)
 
 	if vmCreateConfigResponse.StatusCode != http.StatusCreated {
 		e := fmt.Errorf("%s [%s]", OrkaAPIResponseErrorMessage, vmCreateConfigResponse.Status)
 		ui.Error(e.Error())
+		ui.Error(vmCreateConfigResponseData.Errors[0].Message)
 		state.Put("error", e)
 		s.createVMFailed = true
 		return multistep.ActionHalt
@@ -218,12 +222,13 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 
 	defer vmDeployResponse.Body.Close()
 	var vmDeployResponseData VMDeployResponse
-	vmDeployResponseBodyBytes, _ := ioutil.ReadAll(vmDeployResponse.Body)
+	vmDeployResponseBodyBytes, _ := io.ReadAll(vmDeployResponse.Body)
 	json.Unmarshal(vmDeployResponseBodyBytes, &vmDeployResponseData)
 
 	if vmDeployResponse.StatusCode != http.StatusOK {
 		e := fmt.Errorf("Error from API while deploying Orka VM: %s", vmDeployResponse.Status)
 		state.Put("error", e)
+		ui.Error(vmDeployResponseData.Errors[0].Message)
 		s.createVMFailed = true
 		return multistep.ActionHalt
 	}
@@ -300,7 +305,6 @@ func (s *stepOrkaCreate) precopyImageDelete(state multistep.StateBag) error {
 	}
 
 	ui.Say(fmt.Sprintf("Image deleted [%s]", imageDeleteResponse.Status))
-	imageDeleteResponse.Body.Close()
 
 	return nil
 }
@@ -393,17 +397,20 @@ func (s *stepOrkaCreate) Cleanup(state multistep.StateBag) {
 
 	defer healthCheckResponse.Body.Close()
 
+	var healthCheckResponseData HealthCheckResponse
+	healthCheckResponseBodyBytes, _ := io.ReadAll(healthCheckResponse.Body)
+	json.Unmarshal(healthCheckResponseBodyBytes, &healthCheckResponseData)
+
 	if healthCheckResponse.StatusCode != http.StatusOK {
 		e := fmt.Errorf("%s [%s]", OrkaAPIResponseErrorMessage, healthCheckResponse.Status)
 		ui.Error(e.Error())
+		ui.Error(healthCheckResponseData.Errors[0].Message)
 		state.Put("error", e)
 	}
 
-	var healthCheckResponseData HealthCheckResponse
-	healthCheckResponseBodyBytes, _ := ioutil.ReadAll(healthCheckResponse.Body)
-	json.Unmarshal(healthCheckResponseBodyBytes, &healthCheckResponseData)
-
 	serverVersion, _ := version.NewVersion(healthCheckResponseData.Version)
+
+	// Orka Version where the token system moved from multi to single token architechture
 	singleTokenVersion, _ := version.NewVersion("2.1.1")
 
 	if serverVersion.LessThanOrEqual(singleTokenVersion) {


### PR DESCRIPTION
This pull enhances packer logging to push errors from orka through to the packer ui. It also depricates `ioutil.ReadAll` for `io.ReadAll`. 