### PR TITLE
Extend context timeout for image saves

### DIFF
--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -23,7 +23,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	ui := state.Get("ui").(packer.Ui)
 	vmid := state.Get("vmid").(string)
 	token := state.Get("token").(string)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Hour)
 
 	defer cancel()
 
@@ -41,7 +41,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	if config.ImagePrecopy {
 		// If we are using the pre-copy logic, then we just re-commit the image back.
 
-		ui.Say("Committing existing image since pre-copy is being used")
+
 		ui.Say("Please wait as this can take a little while...")
 
 		imageCommitRequestData := ImageCommitRequest{vmid}

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -42,6 +42,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 		// If we are using the pre-copy logic, then we just re-commit the image back.
 
 
+		ui.Say("Committing existing image since pre-copy is being used")
 		ui.Say("Please wait as this can take a little while...")
 
 		imageCommitRequestData := ImageCommitRequest{vmid}

--- a/builder/orka/step_orka_create.go
+++ b/builder/orka/step_orka_create.go
@@ -68,7 +68,8 @@ func (s *stepOrkaCreate) Run(ctx context.Context, state multistep.StateBag) mult
 	token, err := s.createOrkaToken(state)
 
 	if err != nil {
-		ui.Error(fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err).Error())
+		e := fmt.Errorf("%s [%s]", OrkaAPIRequestErrorMessage, err)
+		ui.Error(e.Error())
 		state.Put("error", err)
 		s.loginFailed = true
 		return multistep.ActionHalt


### PR DESCRIPTION
Extend the image commit/save context timeout from 30 minutes to 3 hours to allow for larger apple silicon images time to save. 