### PR TITLE
Add disk sync step before saving a new image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     macstadium-orka = {
-      version = ">= 2.3.0"
+      version = ">= 2.3.0, < 3.0.0"
       source  = "github.com/macstadium/macstadium-orka"
     }
   }
 }
 ```
-
 
 #### Manual installation
 

--- a/builder/orka/builder.go
+++ b/builder/orka/builder.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/macstadium/packer-plugin-macstadium-orka/mocks"
 )
@@ -16,7 +16,7 @@ import (
 const BuilderId = "orka"
 
 type HttpClient interface {
-    Do(req *http.Request) (*http.Response, error)
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // Builder ...
@@ -38,7 +38,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	return nil, warnings, nil
 }
-
 
 func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (packer.Artifact, error) {
 	// Setup the state bag and initial state for the steps.
@@ -62,12 +61,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	// Iniitialize communicatior
 	var comm = &communicator.StepConnect{
-			Config:    &b.config.CommConfig,
-			Host:      CommHost(b.config.CommConfig.Host()),
-			SSHPort:   CommPort(b.config.CommConfig.Port()),
-			SSHConfig: b.config.CommConfig.SSHConfigFunc(),
+		Config:    &b.config.CommConfig,
+		Host:      CommHost(b.config.CommConfig.Host()),
+		SSHPort:   CommPort(b.config.CommConfig.Port()),
+		SSHConfig: b.config.CommConfig.SSHConfigFunc(),
 	}
-
 
 	// Add our SSH Communicator after our steps.
 	if b.config.Mock == (MockOptions{}) {
@@ -75,6 +73,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			steps,
 			comm,
 			new(commonsteps.StepProvision),
+			new(stepSyncDisk),
 			new(stepCreateImage),
 		)
 	} else {

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -74,6 +74,7 @@ type FlatConfig struct {
 	OrkaVMBuilderName          *string           `mapstructure:"orka_vm_builder_name" cty:"orka_vm_builder_name" hcl:"orka_vm_builder_name"`
 	OrkaVMCPUCore              *int              `mapstructure:"orka_vm_cpu_core" cty:"orka_vm_cpu_core" hcl:"orka_vm_cpu_core"`
 	OrkaVMTag                  *string           `mapstructure:"orka_vm_tag" cty:"orka_vm_tag" hcl:"orka_vm_tag"`
+	OrkaVMTagRequired          *bool             `mapstructure:"orka_vm_tag_required" cty:"orka_vm_tag_required" hcl:"orka_vm_tag_required"`
 	SourceImage                *string           `mapstructure:"source_image" required:"true" cty:"source_image" hcl:"source_image"`
 	ImageName                  *string           `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	SimulateCreate             *bool             `mapstructure:"simulate_create" cty:"simulate_create" hcl:"simulate_create"`
@@ -162,6 +163,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"orka_vm_builder_name":         &hcldec.AttrSpec{Name: "orka_vm_builder_name", Type: cty.String, Required: false},
 		"orka_vm_cpu_core":             &hcldec.AttrSpec{Name: "orka_vm_cpu_core", Type: cty.Number, Required: false},
 		"orka_vm_tag":                  &hcldec.AttrSpec{Name: "orka_vm_tag", Type: cty.String, Required: false},
+		"orka_vm_tag_required":         &hcldec.AttrSpec{Name: "orka_vm_tag_required", Type: cty.Bool, Required: false},
 		"source_image":                 &hcldec.AttrSpec{Name: "source_image", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"simulate_create":              &hcldec.AttrSpec{Name: "simulate_create", Type: cty.Bool, Required: false},

--- a/builder/orka/step_sync_disk.go
+++ b/builder/orka/step_sync_disk.go
@@ -1,0 +1,51 @@
+package orka
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type stepSyncDisk struct {
+}
+
+func (s *stepSyncDisk) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+
+	var comm packer.Communicator
+	if raw, ok := state.Get("communicator").(packer.Communicator); ok {
+		comm = raw
+	}
+
+	var stderr bytes.Buffer
+
+	ui.Say("Syncing disk changes...")
+
+	// Start the command
+	cmd := packer.RemoteCmd{Command: "sync", Stderr: &stderr}
+	if err := comm.Start(ctx, &cmd); err != nil {
+		err := fmt.Errorf("failed to sync disk changes: %w; stdErr=%q", err, stderr.String())
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Wait for it to complete
+	status := cmd.Wait()
+
+	if status != 0 {
+		err := fmt.Errorf("failed to sync disk changes: status code %d; stdErr=%q", status, stderr.String())
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Continue processing
+	return multistep.ActionContinue
+}
+
+func (s *stepSyncDisk) Cleanup(multistep.StateBag) {
+}


### PR DESCRIPTION
This PR adds an additional step to the pipeline, which is supposed to run just before `saving` the new image. The image will run the `sync` system call, which will flush the disk and save all the changes.

Also the PR updates the README, by using a better `version` constraint.