### PR TITLE
fix: use cluster info from orka api

### DIFF
--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type OrkaClient interface {
@@ -60,8 +59,7 @@ func GetOrkaClient(orkaEndpoint, authToken string) (*RealOrkaClient, error) {
 		return nil, err
 	}
 
-	restConfig := config.GetConfigOrDie()
-	restConfig = &rest.Config{
+	restConfig := &rest.Config{
 		Host:        clusterInfo.ApiEndpoint,
 		BearerToken: authToken,
 		TLSClientConfig: rest.TLSClientConfig{


### PR DESCRIPTION
**Why?**

This MR fixes issue with `Unexpected EOF`:

```
Build 'macstadium-orka.image' errored after 7 milliseconds 128 microseconds: unexpected EOF
==> Wait completed after 7 milliseconds 194 microseconds
==> Some builds didn't complete successfully and had errors:
--> macstadium-orka.image: unexpected EOF
==> Builds finished but no artifacts were created.
```

Currently the plugin doesn't produce any error, even if `PACKER_LOG=1` is set, because [GetConfigOrDie()](https://github.com/kubernetes-sigs/controller-runtime/blob/eeaa31c3933f59fdbea6a49f080676c978c2101c/pkg/client/config/config.go#L174) logs message at an ERROR level (it should be set on the code level). If you change `GetConfigOrDie()` to [GetConfig()](https://github.com/kubernetes-sigs/controller-runtime/blob/eeaa31c3933f59fdbea6a49f080676c978c2101c/pkg/client/config/config.go#L76) and handle the error message, it results with:
```
2023/12/13 11:07:52 packer-plugin-macstadium-orka plugin: 2023/12/13 11:07:52 invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variableunable to get kubeconfig
```

It is strange - I need to provide token to API, connection details are gathered from the Orka API endpoint, so what is a purpose of a kubeconfig there? I removed the `GetConfigOrDie()`, because it was overwritten a line below with a RestClient and... it finally started to work!

![out](https://github.com/macstadium/packer-plugin-macstadium-orka/assets/14986712/90ebd8dc-419e-4281-9855-d8251f582d03)


Please merge the change to the default branch, it should help with the `Unexpected EOF` issue.
