### PR TITLE
Add in configurable vm timeouts

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -152,8 +152,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.PackerVMWaitTimeout == 0 {
-		c.PackerVMWaitTimeout = 10
-	}
+		c.PackerVMWaitTimeout = 5
+	} 
 
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {
 		errs = packer.MultiErrorAppend(errs, es...)

--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -60,6 +60,9 @@ type Config struct {
 
 	// Required if Enable Orka IP Mapping is enabled. Map of Node Ips to the external IP values.
 	OrkaNodeIPMap map[string]string `mapstructure:"orka_node_ip_map"`
+
+	// Configuration for VM launch timeout
+	PackerVMWaitTimeout int `mapstructure:"packer_vm_timeout"`
 }
 
 type MockOptions struct {
@@ -146,6 +149,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	if c.OrkaVMBuilderEnableIOBoost == nil {
 		defaultIOBoostValue := true
 		c.OrkaVMBuilderEnableIOBoost = &defaultIOBoostValue
+	}
+
+	if c.PackerVMWaitTimeout == 0 {
+		c.PackerVMWaitTimeout = 10
 	}
 
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {

--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -152,7 +152,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.PackerVMWaitTimeout == 0 {
-		c.PackerVMWaitTimeout = 5
+		c.PackerVMWaitTimeout = 10
 	} 
 
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	OrkaVMBuilderEnableIOBoost *bool             `mapstructure:"orka_enable_io_boost" cty:"orka_enable_io_boost" hcl:"orka_enable_io_boost"`
 	EnableOrkaNodeIPMapping    *bool             `mapstructure:"enable_orka_node_ip_mapping" cty:"enable_orka_node_ip_mapping" hcl:"enable_orka_node_ip_mapping"`
 	OrkaNodeIPMap              map[string]string `mapstructure:"orka_node_ip_map" cty:"orka_node_ip_map" hcl:"orka_node_ip_map"`
+	PackerVMWaitTimeout        *int              `mapstructure:"packer_vm_timeout" cty:"packer_vm_timeout" hcl:"packer_vm_timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -174,6 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"orka_enable_io_boost":         &hcldec.AttrSpec{Name: "orka_enable_io_boost", Type: cty.Bool, Required: false},
 		"enable_orka_node_ip_mapping":  &hcldec.AttrSpec{Name: "enable_orka_node_ip_mapping", Type: cty.Bool, Required: false},
 		"orka_node_ip_map":             &hcldec.AttrSpec{Name: "orka_node_ip_map", Type: cty.Map(cty.String), Required: false},
+		"packer_vm_timeout":            &hcldec.AttrSpec{Name: "packer_vm_timeout", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -84,6 +84,7 @@ func (c *RealOrkaClient) WaitForVm(ctx context.Context, namespace, name string, 
 
 	defer watcher.Stop()
 
+
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Minute)
 	defer cancel()
 

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -21,7 +21,7 @@ type OrkaClient interface {
 	Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
 	Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
-	WaitForVm(ctx context.Context, namespace, name string) (string, int, error)
+	WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error)
 	WaitForImage(ctx context.Context, name string) error
 }
 
@@ -75,7 +75,7 @@ func GetOrkaClient(orkaEndpoint, authToken string) (*RealOrkaClient, error) {
 	return &RealOrkaClient{c}, nil
 }
 
-func (c *RealOrkaClient) WaitForVm(ctx context.Context, namespace, name string) (string, int, error) {
+func (c *RealOrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error) {
 	vmiList := &orkav1.VirtualMachineInstanceList{}
 	watcher, err := c.Watch(ctx, vmiList, client.InNamespace(namespace), client.MatchingFields{"metadata.name": name})
 	if err != nil {
@@ -84,7 +84,7 @@ func (c *RealOrkaClient) WaitForVm(ctx context.Context, namespace, name string) 
 
 	defer watcher.Stop()
 
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Minute)
 	defer cancel()
 
 	for {

--- a/builder/orka/step_create_vm.go
+++ b/builder/orka/step_create_vm.go
@@ -45,7 +45,7 @@ func (s *stepCreateVm) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionHalt
 	}
 
-	sshHost, sshPort, err := client.WaitForVm(ctx, config.OrkaVMBuilderNamespace, config.OrkaVMBuilderName)
+	sshHost, sshPort, err := client.WaitForVm(ctx, config.OrkaVMBuilderNamespace, config.OrkaVMBuilderName, config.PackerVMWaitTimeout)
 	if err != nil {
 		err := fmt.Errorf("failed to wait for the VM: %w", err)
 		state.Put("error", err)

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -95,7 +95,31 @@ The following use cases do not need to be used in most scenarios.
 
 [MacStadium Orka] base images have SSH enabled with username:password  `admin:admin` by default.  See the options from the [SSH Communicator] to see how you can customize that.
 
+# Example Orka CLI Commands
 
+These aren't directly related to this plugin, exactly, but they're a bit of a simplified guide to get you started.  For a more full guide see: [Orka Setup Guide].
+
+```bash
+# Create a config which is used for source_image above
+orka vm create-config -v <vm-name> -c 3 --C 3 --vnc --base-image <base-image> -y
+
+# In essence, this plugin automates running the following 3 commands...
+# Start a VM (using the config above)
+orka vm deploy -v macos-catalina-10-15-5 --vnc -y
+
+# Save a VM's disk to a disk image
+orka image save -v <vmid-here-from-orka-vm-list> -b <destination-image-name> -y
+
+# Stop and remove a VM
+orka vm delete --vm <vmid-here-from-orka-vm-list> -y
+
+# Later to launch future images with this image create a new config to launch...
+orka vm create-config -v <my-new-packerified-vm> -c 3 --C 3 --vnc --base-image <destination-image-name> -y
+# And launch it...
+orka vm deploy -v my-new-packerified-vm --vnc -y
+# Or, alternatively if you're done working with an image and want to delete it...
+orka image delete --image <destination-image-name> -y
+```
 [//]: <> (Ignore, below here are links for ease-of-use above)
 [MacStadium Orka]: https://www.macstadium.com/orka
 [MacStadium]: https://www.macstadium.com

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -95,31 +95,7 @@ The following use cases do not need to be used in most scenarios.
 
 [MacStadium Orka] base images have SSH enabled with username:password  `admin:admin` by default.  See the options from the [SSH Communicator] to see how you can customize that.
 
-# Example Orka CLI Commands
 
-These aren't directly related to this plugin, exactly, but they're a bit of a simplified guide to get you started.  For a more full guide see: [Orka Setup Guide].
-
-```bash
-# Create a config which is used for source_image above
-orka vm create-config -v <vm-name> -c 3 --C 3 --vnc --base-image <base-image> -y
-
-# In essence, this plugin automates running the following 3 commands...
-# Start a VM (using the config above)
-orka vm deploy -v macos-catalina-10-15-5 --vnc -y
-
-# Save a VM's disk to a disk image
-orka image save -v <vmid-here-from-orka-vm-list> -b <destination-image-name> -y
-
-# Stop and remove a VM
-orka vm delete --vm <vmid-here-from-orka-vm-list> -y
-
-# Later to launch future images with this image create a new config to launch...
-orka vm create-config -v <my-new-packerified-vm> -c 3 --C 3 --vnc --base-image <destination-image-name> -y
-# And launch it...
-orka vm deploy -v my-new-packerified-vm --vnc -y
-# Or, alternatively if you're done working with an image and want to delete it...
-orka image delete --image <destination-image-name> -y
-```
 [//]: <> (Ignore, below here are links for ease-of-use above)
 [MacStadium Orka]: https://www.macstadium.com/orka
 [MacStadium]: https://www.macstadium.com

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -71,6 +71,8 @@ build {
 
 * `orka_vm_tag` _(string)_ (optional): Image tag name for the builder VM
 
+* `packer_vm_timeout` _(int)_ (optional): Time packer will wait for a VM to finish launching in minutes. 
+
 # Development / Internal Variables
 
 If you're NOT a dev working on this software you can ignore the following.

--- a/mocks/orka_client_mock.go
+++ b/mocks/orka_client_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 	"errors"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/mocks/orka_client_mock.go
+++ b/mocks/orka_client_mock.go
@@ -43,7 +43,7 @@ func (m OrkaClient) Delete(ctx context.Context, obj client.Object, opts ...clien
 	return nil
 }
 
-func (m OrkaClient) WaitForVm(ctx context.Context, namespace, name string) (string, int, error) {
+func (m OrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error) {
 	if m.ErrorType == errorTypeWaitForVm {
 		return "", 0, errors.New(m.ErrorType)
 	}


### PR DESCRIPTION
Some customers have run into issues where the base image for the packer build is large enough that packer would time out waiting for the VM to launch before it finished caching. This adds an optional flag to configure the timeout duration. The default stays 5 minutes. 