### PR TITLE
Add functionality for enabling and disabling net boost and legacy IO

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -52,8 +52,11 @@ type Config struct {
 	// Do not delete after completion, for some manual testing, for internal dev/testing.
 	NoDeleteVM bool `mapstructure:"no_delete_vm"`
 
-	// Enable Boost IO Performance https://orkadocs.macstadium.com/docs/boost-io-performance
-	OrkaVMBuilderEnableIOBoost *bool `mapstructure:"orka_enable_io_boost"`
+	// Enable Orka Netboost, this should be kept on unless building for an old MacOS version
+	OrkaNetBoost *bool `mapstructure:"orka_enable_net_boost"`
+
+	// Enable Legacy IO, this should be kept off unless you are building for Mojave Image
+	OrkaLegacyIO *bool `mapstructure:"orka_enable_legacy_io"`
 
 	// Enable Orka IP Mapping for exposed IP networking
 	EnableOrkaNodeIPMapping bool `mapstructure:"enable_orka_node_ip_mapping"`
@@ -146,9 +149,14 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.OrkaVMCPUCore = 3
 	}
 
-	if c.OrkaVMBuilderEnableIOBoost == nil {
+	if c.OrkaNetBoost == nil {
 		defaultIOBoostValue := true
-		c.OrkaVMBuilderEnableIOBoost = &defaultIOBoostValue
+		c.OrkaNetBoost = &defaultIOBoostValue
+	}
+
+	if c.OrkaLegacyIO == nil {
+		defaultLegacyIOValue := false
+		c.OrkaLegacyIO = &defaultLegacyIOValue
 	}
 
 	if c.PackerVMWaitTimeout == 0 {

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -10,82 +10,83 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	PackerBuildName            *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
-	PackerBuilderType          *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
-	PackerCoreVersion          *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
-	PackerDebug                *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
-	PackerForce                *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
-	PackerOnError              *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
-	PackerUserVars             map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
-	PackerSensitiveVars        []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Type                       *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
-	PauseBeforeConnect         *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
-	SSHHost                    *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
-	SSHPort                    *int              `mapstructure:"ssh_port" cty:"ssh_port" hcl:"ssh_port"`
-	SSHUsername                *string           `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
-	SSHPassword                *string           `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
-	SSHKeyPairName             *string           `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
-	SSHTemporaryKeyPairName    *string           `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
-	SSHTemporaryKeyPairType    *string           `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
-	SSHTemporaryKeyPairBits    *int              `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
-	SSHCiphers                 []string          `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
-	SSHClearAuthorizedKeys     *bool             `mapstructure:"ssh_clear_authorized_keys" cty:"ssh_clear_authorized_keys" hcl:"ssh_clear_authorized_keys"`
-	SSHKEXAlgos                []string          `mapstructure:"ssh_key_exchange_algorithms" cty:"ssh_key_exchange_algorithms" hcl:"ssh_key_exchange_algorithms"`
-	SSHPrivateKeyFile          *string           `mapstructure:"ssh_private_key_file" undocumented:"true" cty:"ssh_private_key_file" hcl:"ssh_private_key_file"`
-	SSHCertificateFile         *string           `mapstructure:"ssh_certificate_file" cty:"ssh_certificate_file" hcl:"ssh_certificate_file"`
-	SSHPty                     *bool             `mapstructure:"ssh_pty" cty:"ssh_pty" hcl:"ssh_pty"`
-	SSHTimeout                 *string           `mapstructure:"ssh_timeout" cty:"ssh_timeout" hcl:"ssh_timeout"`
-	SSHWaitTimeout             *string           `mapstructure:"ssh_wait_timeout" undocumented:"true" cty:"ssh_wait_timeout" hcl:"ssh_wait_timeout"`
-	SSHAgentAuth               *bool             `mapstructure:"ssh_agent_auth" undocumented:"true" cty:"ssh_agent_auth" hcl:"ssh_agent_auth"`
-	SSHDisableAgentForwarding  *bool             `mapstructure:"ssh_disable_agent_forwarding" cty:"ssh_disable_agent_forwarding" hcl:"ssh_disable_agent_forwarding"`
-	SSHHandshakeAttempts       *int              `mapstructure:"ssh_handshake_attempts" cty:"ssh_handshake_attempts" hcl:"ssh_handshake_attempts"`
-	SSHBastionHost             *string           `mapstructure:"ssh_bastion_host" cty:"ssh_bastion_host" hcl:"ssh_bastion_host"`
-	SSHBastionPort             *int              `mapstructure:"ssh_bastion_port" cty:"ssh_bastion_port" hcl:"ssh_bastion_port"`
-	SSHBastionAgentAuth        *bool             `mapstructure:"ssh_bastion_agent_auth" cty:"ssh_bastion_agent_auth" hcl:"ssh_bastion_agent_auth"`
-	SSHBastionUsername         *string           `mapstructure:"ssh_bastion_username" cty:"ssh_bastion_username" hcl:"ssh_bastion_username"`
-	SSHBastionPassword         *string           `mapstructure:"ssh_bastion_password" cty:"ssh_bastion_password" hcl:"ssh_bastion_password"`
-	SSHBastionInteractive      *bool             `mapstructure:"ssh_bastion_interactive" cty:"ssh_bastion_interactive" hcl:"ssh_bastion_interactive"`
-	SSHBastionPrivateKeyFile   *string           `mapstructure:"ssh_bastion_private_key_file" cty:"ssh_bastion_private_key_file" hcl:"ssh_bastion_private_key_file"`
-	SSHBastionCertificateFile  *string           `mapstructure:"ssh_bastion_certificate_file" cty:"ssh_bastion_certificate_file" hcl:"ssh_bastion_certificate_file"`
-	SSHFileTransferMethod      *string           `mapstructure:"ssh_file_transfer_method" cty:"ssh_file_transfer_method" hcl:"ssh_file_transfer_method"`
-	SSHProxyHost               *string           `mapstructure:"ssh_proxy_host" cty:"ssh_proxy_host" hcl:"ssh_proxy_host"`
-	SSHProxyPort               *int              `mapstructure:"ssh_proxy_port" cty:"ssh_proxy_port" hcl:"ssh_proxy_port"`
-	SSHProxyUsername           *string           `mapstructure:"ssh_proxy_username" cty:"ssh_proxy_username" hcl:"ssh_proxy_username"`
-	SSHProxyPassword           *string           `mapstructure:"ssh_proxy_password" cty:"ssh_proxy_password" hcl:"ssh_proxy_password"`
-	SSHKeepAliveInterval       *string           `mapstructure:"ssh_keep_alive_interval" cty:"ssh_keep_alive_interval" hcl:"ssh_keep_alive_interval"`
-	SSHReadWriteTimeout        *string           `mapstructure:"ssh_read_write_timeout" cty:"ssh_read_write_timeout" hcl:"ssh_read_write_timeout"`
-	SSHRemoteTunnels           []string          `mapstructure:"ssh_remote_tunnels" cty:"ssh_remote_tunnels" hcl:"ssh_remote_tunnels"`
-	SSHLocalTunnels            []string          `mapstructure:"ssh_local_tunnels" cty:"ssh_local_tunnels" hcl:"ssh_local_tunnels"`
-	SSHPublicKey               []byte            `mapstructure:"ssh_public_key" undocumented:"true" cty:"ssh_public_key" hcl:"ssh_public_key"`
-	SSHPrivateKey              []byte            `mapstructure:"ssh_private_key" undocumented:"true" cty:"ssh_private_key" hcl:"ssh_private_key"`
-	WinRMUser                  *string           `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
-	WinRMPassword              *string           `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
-	WinRMHost                  *string           `mapstructure:"winrm_host" cty:"winrm_host" hcl:"winrm_host"`
-	WinRMNoProxy               *bool             `mapstructure:"winrm_no_proxy" cty:"winrm_no_proxy" hcl:"winrm_no_proxy"`
-	WinRMPort                  *int              `mapstructure:"winrm_port" cty:"winrm_port" hcl:"winrm_port"`
-	WinRMTimeout               *string           `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
-	WinRMUseSSL                *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
-	WinRMInsecure              *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
-	WinRMUseNTLM               *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
-	OrkaEndpoint               *string           `mapstructure:"orka_endpoint" required:"true" cty:"orka_endpoint" hcl:"orka_endpoint"`
-	OrkaAuthToken              *string           `mapstructure:"orka_auth_token" required:"true" cty:"orka_auth_token" hcl:"orka_auth_token"`
-	OrkaVMBuilderPrefix        *string           `mapstructure:"orka_vm_builder_prefix" cty:"orka_vm_builder_prefix" hcl:"orka_vm_builder_prefix"`
-	OrkaVMBuilderNamespace     *string           `mapstructure:"orka_vm_builder_namespace" cty:"orka_vm_builder_namespace" hcl:"orka_vm_builder_namespace"`
-	OrkaVMBuilderName          *string           `mapstructure:"orka_vm_builder_name" cty:"orka_vm_builder_name" hcl:"orka_vm_builder_name"`
-	OrkaVMCPUCore              *int              `mapstructure:"orka_vm_cpu_core" cty:"orka_vm_cpu_core" hcl:"orka_vm_cpu_core"`
-	OrkaVMTag                  *string           `mapstructure:"orka_vm_tag" cty:"orka_vm_tag" hcl:"orka_vm_tag"`
-	OrkaVMTagRequired          *bool             `mapstructure:"orka_vm_tag_required" cty:"orka_vm_tag_required" hcl:"orka_vm_tag_required"`
-	SourceImage                *string           `mapstructure:"source_image" required:"true" cty:"source_image" hcl:"source_image"`
-	ImageName                  *string           `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
-	ImageDescription           *string           `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
-	ImageForceOverwrite        *bool             `mapstructure:"image_force_overwrite" required:"false" cty:"image_force_overwrite" hcl:"image_force_overwrite"`
-	Mock                       *FlatMockOptions  `mapstructure:"mock" required:"false" cty:"mock" hcl:"mock"`
-	NoCreateImage              *bool             `mapstructure:"no_create_image" cty:"no_create_image" hcl:"no_create_image"`
-	NoDeleteVM                 *bool             `mapstructure:"no_delete_vm" cty:"no_delete_vm" hcl:"no_delete_vm"`
-	OrkaVMBuilderEnableIOBoost *bool             `mapstructure:"orka_enable_io_boost" cty:"orka_enable_io_boost" hcl:"orka_enable_io_boost"`
-	EnableOrkaNodeIPMapping    *bool             `mapstructure:"enable_orka_node_ip_mapping" cty:"enable_orka_node_ip_mapping" hcl:"enable_orka_node_ip_mapping"`
-	OrkaNodeIPMap              map[string]string `mapstructure:"orka_node_ip_map" cty:"orka_node_ip_map" hcl:"orka_node_ip_map"`
-	PackerVMWaitTimeout        *int              `mapstructure:"packer_vm_timeout" cty:"packer_vm_timeout" hcl:"packer_vm_timeout"`
+	PackerBuildName           *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
+	PackerBuilderType         *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
+	PackerCoreVersion         *string           `mapstructure:"packer_core_version" cty:"packer_core_version" hcl:"packer_core_version"`
+	PackerDebug               *bool             `mapstructure:"packer_debug" cty:"packer_debug" hcl:"packer_debug"`
+	PackerForce               *bool             `mapstructure:"packer_force" cty:"packer_force" hcl:"packer_force"`
+	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
+	PackerUserVars            map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
+	PackerSensitiveVars       []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	Type                      *string           `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
+	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
+	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
+	SSHPort                   *int              `mapstructure:"ssh_port" cty:"ssh_port" hcl:"ssh_port"`
+	SSHUsername               *string           `mapstructure:"ssh_username" cty:"ssh_username" hcl:"ssh_username"`
+	SSHPassword               *string           `mapstructure:"ssh_password" cty:"ssh_password" hcl:"ssh_password"`
+	SSHKeyPairName            *string           `mapstructure:"ssh_keypair_name" undocumented:"true" cty:"ssh_keypair_name" hcl:"ssh_keypair_name"`
+	SSHTemporaryKeyPairName   *string           `mapstructure:"temporary_key_pair_name" undocumented:"true" cty:"temporary_key_pair_name" hcl:"temporary_key_pair_name"`
+	SSHTemporaryKeyPairType   *string           `mapstructure:"temporary_key_pair_type" cty:"temporary_key_pair_type" hcl:"temporary_key_pair_type"`
+	SSHTemporaryKeyPairBits   *int              `mapstructure:"temporary_key_pair_bits" cty:"temporary_key_pair_bits" hcl:"temporary_key_pair_bits"`
+	SSHCiphers                []string          `mapstructure:"ssh_ciphers" cty:"ssh_ciphers" hcl:"ssh_ciphers"`
+	SSHClearAuthorizedKeys    *bool             `mapstructure:"ssh_clear_authorized_keys" cty:"ssh_clear_authorized_keys" hcl:"ssh_clear_authorized_keys"`
+	SSHKEXAlgos               []string          `mapstructure:"ssh_key_exchange_algorithms" cty:"ssh_key_exchange_algorithms" hcl:"ssh_key_exchange_algorithms"`
+	SSHPrivateKeyFile         *string           `mapstructure:"ssh_private_key_file" undocumented:"true" cty:"ssh_private_key_file" hcl:"ssh_private_key_file"`
+	SSHCertificateFile        *string           `mapstructure:"ssh_certificate_file" cty:"ssh_certificate_file" hcl:"ssh_certificate_file"`
+	SSHPty                    *bool             `mapstructure:"ssh_pty" cty:"ssh_pty" hcl:"ssh_pty"`
+	SSHTimeout                *string           `mapstructure:"ssh_timeout" cty:"ssh_timeout" hcl:"ssh_timeout"`
+	SSHWaitTimeout            *string           `mapstructure:"ssh_wait_timeout" undocumented:"true" cty:"ssh_wait_timeout" hcl:"ssh_wait_timeout"`
+	SSHAgentAuth              *bool             `mapstructure:"ssh_agent_auth" undocumented:"true" cty:"ssh_agent_auth" hcl:"ssh_agent_auth"`
+	SSHDisableAgentForwarding *bool             `mapstructure:"ssh_disable_agent_forwarding" cty:"ssh_disable_agent_forwarding" hcl:"ssh_disable_agent_forwarding"`
+	SSHHandshakeAttempts      *int              `mapstructure:"ssh_handshake_attempts" cty:"ssh_handshake_attempts" hcl:"ssh_handshake_attempts"`
+	SSHBastionHost            *string           `mapstructure:"ssh_bastion_host" cty:"ssh_bastion_host" hcl:"ssh_bastion_host"`
+	SSHBastionPort            *int              `mapstructure:"ssh_bastion_port" cty:"ssh_bastion_port" hcl:"ssh_bastion_port"`
+	SSHBastionAgentAuth       *bool             `mapstructure:"ssh_bastion_agent_auth" cty:"ssh_bastion_agent_auth" hcl:"ssh_bastion_agent_auth"`
+	SSHBastionUsername        *string           `mapstructure:"ssh_bastion_username" cty:"ssh_bastion_username" hcl:"ssh_bastion_username"`
+	SSHBastionPassword        *string           `mapstructure:"ssh_bastion_password" cty:"ssh_bastion_password" hcl:"ssh_bastion_password"`
+	SSHBastionInteractive     *bool             `mapstructure:"ssh_bastion_interactive" cty:"ssh_bastion_interactive" hcl:"ssh_bastion_interactive"`
+	SSHBastionPrivateKeyFile  *string           `mapstructure:"ssh_bastion_private_key_file" cty:"ssh_bastion_private_key_file" hcl:"ssh_bastion_private_key_file"`
+	SSHBastionCertificateFile *string           `mapstructure:"ssh_bastion_certificate_file" cty:"ssh_bastion_certificate_file" hcl:"ssh_bastion_certificate_file"`
+	SSHFileTransferMethod     *string           `mapstructure:"ssh_file_transfer_method" cty:"ssh_file_transfer_method" hcl:"ssh_file_transfer_method"`
+	SSHProxyHost              *string           `mapstructure:"ssh_proxy_host" cty:"ssh_proxy_host" hcl:"ssh_proxy_host"`
+	SSHProxyPort              *int              `mapstructure:"ssh_proxy_port" cty:"ssh_proxy_port" hcl:"ssh_proxy_port"`
+	SSHProxyUsername          *string           `mapstructure:"ssh_proxy_username" cty:"ssh_proxy_username" hcl:"ssh_proxy_username"`
+	SSHProxyPassword          *string           `mapstructure:"ssh_proxy_password" cty:"ssh_proxy_password" hcl:"ssh_proxy_password"`
+	SSHKeepAliveInterval      *string           `mapstructure:"ssh_keep_alive_interval" cty:"ssh_keep_alive_interval" hcl:"ssh_keep_alive_interval"`
+	SSHReadWriteTimeout       *string           `mapstructure:"ssh_read_write_timeout" cty:"ssh_read_write_timeout" hcl:"ssh_read_write_timeout"`
+	SSHRemoteTunnels          []string          `mapstructure:"ssh_remote_tunnels" cty:"ssh_remote_tunnels" hcl:"ssh_remote_tunnels"`
+	SSHLocalTunnels           []string          `mapstructure:"ssh_local_tunnels" cty:"ssh_local_tunnels" hcl:"ssh_local_tunnels"`
+	SSHPublicKey              []byte            `mapstructure:"ssh_public_key" undocumented:"true" cty:"ssh_public_key" hcl:"ssh_public_key"`
+	SSHPrivateKey             []byte            `mapstructure:"ssh_private_key" undocumented:"true" cty:"ssh_private_key" hcl:"ssh_private_key"`
+	WinRMUser                 *string           `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
+	WinRMPassword             *string           `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
+	WinRMHost                 *string           `mapstructure:"winrm_host" cty:"winrm_host" hcl:"winrm_host"`
+	WinRMNoProxy              *bool             `mapstructure:"winrm_no_proxy" cty:"winrm_no_proxy" hcl:"winrm_no_proxy"`
+	WinRMPort                 *int              `mapstructure:"winrm_port" cty:"winrm_port" hcl:"winrm_port"`
+	WinRMTimeout              *string           `mapstructure:"winrm_timeout" cty:"winrm_timeout" hcl:"winrm_timeout"`
+	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
+	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
+	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	OrkaEndpoint              *string           `mapstructure:"orka_endpoint" required:"true" cty:"orka_endpoint" hcl:"orka_endpoint"`
+	OrkaAuthToken             *string           `mapstructure:"orka_auth_token" required:"true" cty:"orka_auth_token" hcl:"orka_auth_token"`
+	OrkaVMBuilderPrefix       *string           `mapstructure:"orka_vm_builder_prefix" cty:"orka_vm_builder_prefix" hcl:"orka_vm_builder_prefix"`
+	OrkaVMBuilderNamespace    *string           `mapstructure:"orka_vm_builder_namespace" cty:"orka_vm_builder_namespace" hcl:"orka_vm_builder_namespace"`
+	OrkaVMBuilderName         *string           `mapstructure:"orka_vm_builder_name" cty:"orka_vm_builder_name" hcl:"orka_vm_builder_name"`
+	OrkaVMCPUCore             *int              `mapstructure:"orka_vm_cpu_core" cty:"orka_vm_cpu_core" hcl:"orka_vm_cpu_core"`
+	OrkaVMTag                 *string           `mapstructure:"orka_vm_tag" cty:"orka_vm_tag" hcl:"orka_vm_tag"`
+	OrkaVMTagRequired         *bool             `mapstructure:"orka_vm_tag_required" cty:"orka_vm_tag_required" hcl:"orka_vm_tag_required"`
+	SourceImage               *string           `mapstructure:"source_image" required:"true" cty:"source_image" hcl:"source_image"`
+	ImageName                 *string           `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
+	ImageDescription          *string           `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
+	ImageForceOverwrite       *bool             `mapstructure:"image_force_overwrite" required:"false" cty:"image_force_overwrite" hcl:"image_force_overwrite"`
+	Mock                      *FlatMockOptions  `mapstructure:"mock" required:"false" cty:"mock" hcl:"mock"`
+	NoCreateImage             *bool             `mapstructure:"no_create_image" cty:"no_create_image" hcl:"no_create_image"`
+	NoDeleteVM                *bool             `mapstructure:"no_delete_vm" cty:"no_delete_vm" hcl:"no_delete_vm"`
+	OrkaNetBoost              *bool             `mapstructure:"orka_enable_net_boost" cty:"orka_enable_net_boost" hcl:"orka_enable_net_boost"`
+	OrkaLegacyIO              *bool             `mapstructure:"orka_enable_legacy_io" cty:"orka_enable_legacy_io" hcl:"orka_enable_legacy_io"`
+	EnableOrkaNodeIPMapping   *bool             `mapstructure:"enable_orka_node_ip_mapping" cty:"enable_orka_node_ip_mapping" hcl:"enable_orka_node_ip_mapping"`
+	OrkaNodeIPMap             map[string]string `mapstructure:"orka_node_ip_map" cty:"orka_node_ip_map" hcl:"orka_node_ip_map"`
+	PackerVMWaitTimeout       *int              `mapstructure:"packer_vm_timeout" cty:"packer_vm_timeout" hcl:"packer_vm_timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -172,7 +173,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"mock":                         &hcldec.BlockSpec{TypeName: "mock", Nested: hcldec.ObjectSpec((*FlatMockOptions)(nil).HCL2Spec())},
 		"no_create_image":              &hcldec.AttrSpec{Name: "no_create_image", Type: cty.Bool, Required: false},
 		"no_delete_vm":                 &hcldec.AttrSpec{Name: "no_delete_vm", Type: cty.Bool, Required: false},
-		"orka_enable_io_boost":         &hcldec.AttrSpec{Name: "orka_enable_io_boost", Type: cty.Bool, Required: false},
+		"orka_enable_net_boost":        &hcldec.AttrSpec{Name: "orka_enable_net_boost", Type: cty.Bool, Required: false},
+		"orka_enable_legacy_io":        &hcldec.AttrSpec{Name: "orka_enable_legacy_io", Type: cty.Bool, Required: false},
 		"enable_orka_node_ip_mapping":  &hcldec.AttrSpec{Name: "enable_orka_node_ip_mapping", Type: cty.Bool, Required: false},
 		"orka_node_ip_map":             &hcldec.AttrSpec{Name: "orka_node_ip_map", Type: cty.Map(cty.String), Required: false},
 		"packer_vm_timeout":            &hcldec.AttrSpec{Name: "packer_vm_timeout", Type: cty.Number, Required: false},

--- a/builder/orka/step_create_vm.go
+++ b/builder/orka/step_create_vm.go
@@ -34,8 +34,8 @@ func (s *stepCreateVm) Run(ctx context.Context, state multistep.StateBag) multis
 			CPU:         config.OrkaVMCPUCore,
 			Tag:         &config.OrkaVMTag,
 			TagRequired: &config.OrkaVMTagRequired,
-			LegacyIO: config.OrkaLegacyIO,
-			NetBoost: config.OrkaNetBoost,
+			LegacyIO:    config.OrkaLegacyIO,
+			NetBoost:    config.OrkaNetBoost,
 		},
 	}
 

--- a/builder/orka/step_create_vm.go
+++ b/builder/orka/step_create_vm.go
@@ -34,6 +34,8 @@ func (s *stepCreateVm) Run(ctx context.Context, state multistep.StateBag) multis
 			CPU:         config.OrkaVMCPUCore,
 			Tag:         &config.OrkaVMTag,
 			TagRequired: &config.OrkaVMTagRequired,
+			LegacyIO: config.OrkaLegacyIO,
+			NetBoost: config.OrkaNetBoost,
 		},
 	}
 

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -65,7 +65,7 @@ build {
 
 * `orka_vm_builder_prefix` _(string)_ (optional): If orka_vm_builder_name is not passed in, you can add prefix to the virtual machine name that the plugin appends a timestamp to. Defaults to packer.
 
-* `orka_enable_net_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), on by default
+* `orka_enable_net_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/cli-reference#options-62), on by default (Intel Only)
 
 * `orka_enable_legacy_io` _(bool)_ (optional): Enable or Disable [Legacy IO](https://orkadocs.macstadium.com/docs/orka-v310#intel-only-support-for-old-os-versions) (Intel Only)
 

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -81,9 +81,9 @@ If you're NOT a dev working on this software you can ignore the following.
 
 But, if you are building/editing/updating this software, you may want to turn on most or all of the following options.  See the [examples/orka.pkr.hcl](./examples/orka.pkr.hcl) or [examples/macos.json](./examples/macos-catalina.json).
 
-* `do_not_delete` _(boolean)_ (optional) _*- for devs*_:  By default this plugin automatically deletes the VM afterwards if all scripts ran successfully. This is useful for debugging builds.
+* `do_not_delete` _(bool)_ (optional) _*- for devs*_:  By default this plugin automatically deletes the VM afterwards if all scripts ran successfully. This is useful for debugging builds.
 
-* `do_not_image` _(boolean)_ (optional) _*- for devs*_ By default this plugin automatically creates an image of the VM after any provisioning steps.  This is useful for debugging builds.
+* `do_not_image` _(bool)_ (optional) _*- for devs*_ By default this plugin automatically creates an image of the VM after any provisioning steps.  This is useful for debugging builds.
 
 # Advanced Use Cases
 

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -65,7 +65,7 @@ build {
 
 * `orka_vm_builder_prefix` _(string)_ (optional): If orka_vm_builder_name is not passed in, you can add prefix to the virtual machine name that the plugin appends a timestamp to. Defaults to packer.
 
-* `orka_enable_io_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), on by default
+* `orka_enable_net_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), on by default
 
 * `orka_enable_legacy_io` _(bool)_ (optional): Enable or Disable [Legacy IO](https://orkadocs.macstadium.com/docs/orka-v310#intel-only-support-for-old-os-versions) (Intel Only)
 

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -65,7 +65,9 @@ build {
 
 * `orka_vm_builder_prefix` _(string)_ (optional): If orka_vm_builder_name is not passed in, you can add prefix to the virtual machine name that the plugin appends a timestamp to. Defaults to packer.
 
-- `orka_enable_io_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), on by default
+* `orka_enable_io_boost` _(bool)_ (optional): Enable or Disable [Boost IO Performance](https://orkadocs.macstadium.com/docs/boost-io-performance), on by default
+
+* `orka_enable_legacy_io` _(bool)_ (optional): Enable or Disable [Legacy IO](https://orkadocs.macstadium.com/docs/orka-v310#intel-only-support-for-old-os-versions) (Intel Only)
 
 * `orka_vm_cpu_core` _(int)_ (optional):  Number of cpu cores to use with the virtual machine.
 

--- a/orkaapi/api/v1/virtualmachineinstance_types.go
+++ b/orkaapi/api/v1/virtualmachineinstance_types.go
@@ -46,6 +46,8 @@ type VirtualMachineInstanceSpec struct {
 	VNCConsole *bool `json:"vncConsole,omitempty"`
 	// The scheduler handling the deployment. One of: default, most-allocated. When set to most-allocated, VirtualMachineInstances are scheduled to OrkaNodes having most of their resources allocated. The default setting keeps used vs free resources balanced between OrkaNodes
 	Scheduler *string `json:"scheduler,omitempty"`
+	// Boolean setting if legacy IO is enabled
+	LegacyIO *bool `json:"legacyIO,omitempty"`
 	// Boolean setting if Network boost is enabled
 	NetBoost *bool `json:"netBoost,omitempty"`
 	// Boolean setting if GPU passthrough is enabled. When enabled, VncConsole must be disabled


### PR DESCRIPTION
This PR enables the ability to enable and disable net boost and legacy IO when launching VMs for image building. 

Today customers who are building for legacy Mojave and High Sierra images, they are not able to use packer because it does not support the settings required to launch these VMs. This change adds the ability to configure those flags. 