### PR TITLE
Add OCI VM Push functionality

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	ImageName           string `mapstructure:"image_name" required:"false"`
 	ImageDescription    string `mapstructure:"image_description" required:"false"`
 	ImageForceOverwrite bool   `mapstructure:"image_force_overwrite" required:"false"`
+	SaveToOCI *bool `mapstructure:"save_to_oci_registry" required:"false"`
 
 	Mock MockOptions `mapstructure:"mock" required:"false"`
 
@@ -142,6 +143,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 		// log.Printf("No Destination Image Specified. Using default: %s", name)
 		c.ImageName = name
+	}
+	
+	if c.SaveToOCI == nil {
+		defaultSaveToOCIValue := false
+		c.SaveToOCI = &defaultSaveToOCIValue
 	}
 
 	// If we didn't specify the number of cores, set it to the default of 3.

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -79,6 +79,7 @@ type FlatConfig struct {
 	ImageName                 *string           `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	ImageDescription          *string           `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageForceOverwrite       *bool             `mapstructure:"image_force_overwrite" required:"false" cty:"image_force_overwrite" hcl:"image_force_overwrite"`
+	SaveToOCI                 *bool             `mapstructure:"save_to_oci_registry" required:"false" cty:"save_to_oci_registry" hcl:"save_to_oci_registry"`
 	Mock                      *FlatMockOptions  `mapstructure:"mock" required:"false" cty:"mock" hcl:"mock"`
 	NoCreateImage             *bool             `mapstructure:"no_create_image" cty:"no_create_image" hcl:"no_create_image"`
 	NoDeleteVM                *bool             `mapstructure:"no_delete_vm" cty:"no_delete_vm" hcl:"no_delete_vm"`
@@ -170,6 +171,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_force_overwrite":        &hcldec.AttrSpec{Name: "image_force_overwrite", Type: cty.Bool, Required: false},
+		"save_to_oci_registry":         &hcldec.AttrSpec{Name: "save_to_oci_registry", Type: cty.Bool, Required: false},
 		"mock":                         &hcldec.BlockSpec{TypeName: "mock", Nested: hcldec.ObjectSpec((*FlatMockOptions)(nil).HCL2Spec())},
 		"no_create_image":              &hcldec.AttrSpec{Name: "no_create_image", Type: cty.Bool, Required: false},
 		"no_delete_vm":                 &hcldec.AttrSpec{Name: "no_delete_vm", Type: cty.Bool, Required: false},

--- a/orkaapi/api/v1/virtualmachineinstance_types.go
+++ b/orkaapi/api/v1/virtualmachineinstance_types.go
@@ -117,6 +117,17 @@ type VirtualMachineInstance struct {
 	Status VirtualMachineInstanceStatus `json:"status,omitempty"`
 }
 
+// OrkaVMPushRequestModel describes the expected JSON input data for the vm push operation.
+type OrkaVMPushRequestModel struct {
+	ImageReference string `json:"imageReference" binding:"required" example:"ghcr.io/organization-name/orka-images/base:latest"`
+}
+
+// OrkaVMPushResponseModel describes the JSON response data for the vm push operation.
+type OrkaVMPushResponseModel struct {
+	JobName string `json:"jobName"`
+}
+
+
 //+kubebuilder:object:root=true
 
 // VirtualMachineInstanceList contains a list of VirtualMachineInstance


### PR DESCRIPTION
Orka now has the ability to store images in OCI compatible image registries. This change allows for packer to push directly to those registries without needing to use attached storage as an intermediary. 