### PR TITLE
Add image push timeout configuration 

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -66,6 +66,9 @@ type Config struct {
 
 	// Configuration for VM launch timeout
 	PackerVMWaitTimeout int `mapstructure:"packer_vm_timeout"`
+
+	// Configuration for VM Push timeout
+	PackerPushTimeout int `mapstructure:"packer_push_timeout"`
 }
 
 type MockOptions struct {
@@ -161,6 +164,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.PackerVMWaitTimeout == 0 {
 		c.PackerVMWaitTimeout = 10
+	}
+
+	if c.PackerPushTimeout == 0 {
+		c.PackerPushTimeout = 60
 	}
 
 	if es := c.CommConfig.Prepare(nil); len(es) > 0 {

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -87,6 +87,7 @@ type FlatConfig struct {
 	EnableOrkaNodeIPMapping   *bool             `mapstructure:"enable_orka_node_ip_mapping" cty:"enable_orka_node_ip_mapping" hcl:"enable_orka_node_ip_mapping"`
 	OrkaNodeIPMap             map[string]string `mapstructure:"orka_node_ip_map" cty:"orka_node_ip_map" hcl:"orka_node_ip_map"`
 	PackerVMWaitTimeout       *int              `mapstructure:"packer_vm_timeout" cty:"packer_vm_timeout" hcl:"packer_vm_timeout"`
+	PackerPushTimeout         *int              `mapstructure:"packer_push_timeout" cty:"packer_push_timeout" hcl:"packer_push_timeout"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -178,6 +179,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"enable_orka_node_ip_mapping":  &hcldec.AttrSpec{Name: "enable_orka_node_ip_mapping", Type: cty.Bool, Required: false},
 		"orka_node_ip_map":             &hcldec.AttrSpec{Name: "orka_node_ip_map", Type: cty.Map(cty.String), Required: false},
 		"packer_vm_timeout":            &hcldec.AttrSpec{Name: "packer_vm_timeout", Type: cty.Number, Required: false},
+		"packer_push_timeout":          &hcldec.AttrSpec{Name: "packer_push_timeout", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -36,7 +36,7 @@ type OrkaClient interface {
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
 	WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error)
 	WaitForImage(ctx context.Context, name string) error
-	WaitForPush(ctx context.Context, timeout int, namespace, name string) error
+	WaitForPush(ctx context.Context, namespace, name string, timeout int) error
 }
 
 type RealOrkaClient struct {
@@ -192,7 +192,7 @@ func (c *RealOrkaClient) waitForImage(ctx context.Context, name string) error {
 	}
 }
 
-func (c *RealOrkaClient) WaitForPush(ctx context.Context, timeout int, namespace, name string) error {
+func (c *RealOrkaClient) WaitForPush(ctx context.Context, namespace, name string, timeout int) error {
 	return RetryOnWatcherErrorWithTimeout(ctx, time.Duration(timeout)*time.Minute, func(contextWithTimeout context.Context) error {
 		return c.waitForPush(contextWithTimeout, namespace, name)
 	}, 1*time.Second)

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -36,7 +36,7 @@ type OrkaClient interface {
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
 	WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error)
 	WaitForImage(ctx context.Context, name string) error
-	WaitForPush(ctx context.Context, namespace, name string) error
+	WaitForPush(ctx context.Context, timeout int, namespace, name string) error
 }
 
 type RealOrkaClient struct {
@@ -192,9 +192,8 @@ func (c *RealOrkaClient) waitForImage(ctx context.Context, name string) error {
 	}
 }
 
-// TODO: Add configurable image push timeout
-func (c *RealOrkaClient) WaitForPush(ctx context.Context, namespace, name string) error {
-	return RetryOnWatcherErrorWithTimeout(ctx, 1*time.Hour, func(contextWithTimeout context.Context) error {
+func (c *RealOrkaClient) WaitForPush(ctx context.Context, timeout int, namespace, name string) error {
+	return RetryOnWatcherErrorWithTimeout(ctx, time.Duration(timeout)*time.Minute, func(contextWithTimeout context.Context) error {
 		return c.waitForPush(contextWithTimeout, namespace, name)
 	}, 1*time.Second)
 }

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -208,6 +208,7 @@ func imageSaveOCI(ctx context.Context, state multistep.StateBag, config *Config)
 	timeout := config.PackerPushTimeout
 	err = orkaClient.WaitForPush(ctx, config.OrkaVMBuilderNamespace, r.JobName, timeout)
 	if err != nil {
+		state.Put("error", err)
 		ui.Error(fmt.Sprintf("image [%s] push failed: %s", config.ImageName, err))
 		return multistep.ActionHalt
 	}

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -206,7 +206,7 @@ func imageSaveOCI(ctx context.Context, state multistep.StateBag, config *Config)
 	ui.Say(waitForSaveMessage)
 
 	timeout := config.PackerPushTimeout
-	err = orkaClient.WaitForPush(ctx, timeout, config.OrkaVMBuilderNamespace, r.JobName)
+	err = orkaClient.WaitForPush(ctx, config.OrkaVMBuilderNamespace, r.JobName, timeout)
 	if err != nil {
 		ui.Error(fmt.Sprintf("image [%s] push failed: %s", config.ImageName, err))
 		return multistep.ActionHalt

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -205,7 +205,8 @@ func imageSaveOCI(ctx context.Context, state multistep.StateBag, config *Config)
 	ui.Say(fmt.Sprintf("image [%s] push began successfully.", config.ImageName))
 	ui.Say(waitForSaveMessage)
 
-	err = orkaClient.WaitForPush(ctx, config.OrkaVMBuilderNamespace, r.JobName)
+	timeout := config.PackerPushTimeout
+	err = orkaClient.WaitForPush(ctx, timeout, config.OrkaVMBuilderNamespace, r.JobName)
 	if err != nil {
 		ui.Error(fmt.Sprintf("image [%s] push failed: %s", config.ImageName, err))
 		return multistep.ActionHalt

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -205,8 +205,7 @@ func imageSaveOCI(ctx context.Context, state multistep.StateBag, config *Config)
 	ui.Say(fmt.Sprintf("image [%s] push began successfully.", config.ImageName))
 	ui.Say(waitForSaveMessage)
 
-	timeout := config.PackerPushTimeout
-	err = orkaClient.WaitForPush(ctx, config.OrkaVMBuilderNamespace, r.JobName, timeout)
+	err = orkaClient.WaitForPush(ctx, config.OrkaVMBuilderNamespace, r.JobName, config.PackerPushTimeout)
 	if err != nil {
 		state.Put("error", err)
 		ui.Error(fmt.Sprintf("image [%s] push failed: %s", config.ImageName, err))

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -75,6 +75,8 @@ build {
 
 * `packer_vm_timeout` _(int)_ (optional): Time packer will wait for a VM to finish launching in minutes. 
 
+* `packer_push_timeout` _(int)_ (optional): Timeout in minutes packer will wait for image to push to an OCI registry. If the timeout is reached, the image will continue to push in the background. Default 60 minutes.
+
 # Development / Internal Variables
 
 If you're NOT a dev working on this software you can ignore the following.

--- a/mocks/orka_client_mock.go
+++ b/mocks/orka_client_mock.go
@@ -62,7 +62,7 @@ func (m OrkaClient) WaitForImage(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m OrkaClient) WaitForPush(ctx context.Context, namespace, name string) error {
+func (m OrkaClient) WaitForPush(ctx context.Context, timeout int, namespace, name string) error {
 	if m.ErrorType == errorTypeWaitForPush {
 		return errors.New(m.ErrorType)
 	}

--- a/mocks/orka_client_mock.go
+++ b/mocks/orka_client_mock.go
@@ -62,7 +62,7 @@ func (m OrkaClient) WaitForImage(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m OrkaClient) WaitForPush(ctx context.Context, timeout int, namespace, name string) error {
+func (m OrkaClient) WaitForPush(ctx context.Context, namespace, name string, timeout int) error {
 	if m.ErrorType == errorTypeWaitForPush {
 		return errors.New(m.ErrorType)
 	}


### PR DESCRIPTION
This PR adds the configuration variable `packer_push_timeout` to the config spec to allow a user to set the time that the plugin will wait while pushing an image. 

The default has been kept the same at 60 minutes. 

To test this change, use a configuration like below to ensure a low timeout time:

```
variable "ORKA_TOKEN" {
  default = env("ORKA_TOKEN")
}

source "macstadium-orka" "image" {
  source_image      = "ghcr.io/macstadium/orka-images/sequoia:latest"
  image_name        = <OCI REGISTRY URI>
  image_description = "I was created with Packer!"
  orka_endpoint     = "http://10.221.188.20"
  orka_auth_token   = var.ORKA_TOKEN
  packer_push_timeout = 1
}

build {
  sources = [
    "macstadium-orka.image"
  ]
   provisioner "shell" {
    inline = [
      "echo we are running on the remote host",
      "hostname",
      "touch .we-ran-packer-successfully"
    ]
  }
}

```

The expected output for a build that reaches the timeout is:

```
macstadium-orka.image: output will be in this color.

==> macstadium-orka.image: Builder VM configuration will use base image [ghcr.io/macstadium/orka-images/sequoia:latest]
==> macstadium-orka.image: Deploying a VM [packer-1757014570] in namespace [orka-default]
==> macstadium-orka.image: Created VM [packer-1757014570] in namespace [orka-default]
==> macstadium-orka.image: SSH server will be available at [10.221.188.31:8823]
==> macstadium-orka.image: Using SSH communicator to connect: 10.221.188.31
==> macstadium-orka.image: Waiting for SSH to become available...
==> macstadium-orka.image: Connected to SSH!
==> macstadium-orka.image: Provisioning with shell script: /var/folders/zh/hbvmq7zx5md3_sff_smhnn_00000gn/T/packer-shell1775897121
    macstadium-orka.image: we are running on the remote host
    macstadium-orka.image: admins-Virtual-Machine.local
==> macstadium-orka.image: Syncing disk changes...
==> macstadium-orka.image: Image push is using VM [packer-1757014570] in namespace [orka-default]
==> macstadium-orka.image: Pushing new image to registry [585768164896.dkr.ecr.us-east-1.amazonaws.com/cflanagan/packer:timeout-test-v1]
==> macstadium-orka.image: image [585768164896.dkr.ecr.us-east-1.amazonaws.com/cflanagan/packer:timeout-test-v1] push began successfully.
==> macstadium-orka.image: Please wait as this can take a little while...
==> macstadium-orka.image: image [585768164896.dkr.ecr.us-east-1.amazonaws.com/cflanagan/packer:timeout-test-v1] push failed: context deadline exceeded
==> macstadium-orka.image: Provisioning step had errors: Running the cleanup provisioner, if present...
==> macstadium-orka.image: Cleaning up builder VM [packer-1757014570] from namespace [orka-default]
Build 'macstadium-orka.image' errored after 1 minute 16 seconds: context deadline exceeded

==> Wait completed after 1 minute 16 seconds

==> Some builds didn't complete successfully and had errors:
--> macstadium-orka.image: context deadline exceeded

==> Builds finished but no artifacts were created.
```