### PR TITLE
Correctly handle API Public IP Feature

### DIFF
--- a/builder/orka/builder.go
+++ b/builder/orka/builder.go
@@ -3,6 +3,7 @@ package orka
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -52,7 +53,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	var client OrkaClient
 
 	if b.config.Mock == (MockOptions{}) {
-		if c, err := GetOrkaClient(b.config.OrkaEndpoint, b.config.OrkaAuthToken); err != nil {
+		if c, err := GetOrkaClient(b.config.OrkaEndpoint, b.config.OrkaAuthToken, &b.config); err != nil {
 			return nil, fmt.Errorf("failed to create k8s client: %w", err)
 		} else {
 			client = c

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -44,7 +44,7 @@ type RealOrkaClient struct {
 }
 
 // GetOrkaClient returns a runtime client with the on-disk discovery cache enabled
-func GetOrkaClient(orkaEndpoint, authToken string) (*RealOrkaClient, error) {
+func GetOrkaClient(orkaEndpoint, authToken string, config *Config) (*RealOrkaClient, error) {
 	sch := runtime.NewScheme()
 	if err := orkav1.AddToScheme(sch); err != nil {
 		log.Fatal("failed to add orkav1 to scheme")
@@ -86,7 +86,7 @@ func GetOrkaClient(orkaEndpoint, authToken string) (*RealOrkaClient, error) {
 	}
 
 	// Determine if using a public IP address and update config with k8s apiserver name
-	if clusterInfo.APIDomain != "" {
+	if clusterInfo.APIDomain != "" && config.EnableOrkaNodeIPMapping {
 		ip := lookupIP(orkaEndpoint)
 		if ip != nil && !ip.IsPrivate() {
 			restConfig.Host = fmt.Sprintf("https://%s", ip)


### PR DESCRIPTION
Use the EnableOrkaNodeIPMapping flag to determine if the public IP feature should be used. If it is being used, then the CLI uses the same public IP for the API and K8s servers. If it is not being used, the CLI respects the K8s api server value.

This fixes the behavior when Orka is in AWS or On-Premise.