### PR TITLE
docs: fix typos + update provisioning steps

### DIFF
--- a/examples/sequoia-155-dev-toolkit.hcl
+++ b/examples/sequoia-155-dev-toolkit.hcl
@@ -42,10 +42,12 @@ build {
 
   provisioner "shell" {
     inline = [
+      "echo 'admin' | sudo -S sh -c 'echo \"admin ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers'",
       "echo 'Installing Homebrew'",
-      "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
     ]
   }
+
   provisioner "shell" {
     inline = [
       "# Add Homebrew to PATH in shell configuration files, use Homebrew to install Fastlane, swiftlint, Git, swift, Cocoapods, and xcodes",
@@ -57,7 +59,6 @@ build {
       "brew install git",
       "brew install cocoapods",
       "brew install xcodesorg/made/xcodes",
-      "brew install swiftlint",
       "brew install swift",
     ]
   }


### PR DESCRIPTION
removed extra close brace, updated homebrew installation provisioning step to correct build failures related to permissions, and removed swiftlint from the template as it requires a full version of XCode to already be installed.