### PR TITLE
Update sequoia-155-dev-toolkit.pkr.hcl

### DIFF
--- a/examples/sequoia-155-dev-toolkit.pkr.hcl
+++ b/examples/sequoia-155-dev-toolkit.pkr.hcl
@@ -42,9 +42,16 @@ build {
 
   provisioner "shell" {
     inline = [
-      "echo 'admin' | sudo -S sh -c 'echo \"admin ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers'",
+      "echo 'Setting up passwordless sudo for admin user'",
+      "echo 'admin' | sudo -S sh -c \"echo 'admin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/admin-nopasswd\"",
+      "echo 'admin' | sudo -S chmod 0440 /etc/sudoers.d/admin-nopasswd",
       "echo 'Installing Homebrew'",
+      "echo 'admin' | sudo -S mkdir -p /opt/homebrew",
+      "echo 'admin' | sudo -S chown -R admin:admin /opt/homebrew",
       "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+      "echo 'Cleaning up passwordless sudo'",
+      "echo 'admin' | sudo -S rm -f /etc/sudoers.d/admin-nopasswd",
+      "echo 'Homebrew installation completed'"
     ]
   }
 

--- a/examples/sequoia-155-dev-toolkit.pkr.hcl
+++ b/examples/sequoia-155-dev-toolkit.pkr.hcl
@@ -43,14 +43,14 @@ build {
   provisioner "shell" {
     inline = [
       "echo 'Setting up passwordless sudo for admin user'",
-      "echo 'admin' | sudo -S sh -c \"echo 'admin ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/admin-nopasswd\"",
-      "echo 'admin' | sudo -S chmod 0440 /etc/sudoers.d/admin-nopasswd",
+      "echo '${var.ssh_password}' | sudo -S sh -c \"echo '${var.ssh_username} ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/${var.ssh_username}-nopasswd\"",
+      "echo '${var.ssh_password}' | sudo -S chmod 0644 /etc/sudoers.d/${var.ssh_username}-nopasswd",
       "echo 'Installing Homebrew'",
-      "echo 'admin' | sudo -S mkdir -p /opt/homebrew",
-      "echo 'admin' | sudo -S chown -R admin:admin /opt/homebrew",
+      "echo '${var.ssh_password}' | sudo -S mkdir -p /opt/homebrew",
+      "echo '${var.ssh_password}' | sudo -S chown -R ${var.ssh_username}:${var.ssh_username} /opt/homebrew",
       "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
       "echo 'Cleaning up passwordless sudo'",
-      "echo 'admin' | sudo -S rm -f /etc/sudoers.d/admin-nopasswd",
+      "echo '${var.ssh_password}' | sudo -S rm -f /etc/sudoers.d/${var.ssh_username}-nopasswd",
       "echo 'Homebrew installation completed'"
     ]
   }
@@ -59,8 +59,8 @@ build {
     inline = [
       "# Add Homebrew to PATH in shell configuration files, use Homebrew to install Fastlane, swiftlint, Git, swift, Cocoapods, and xcodes",
       // Add or delete tools from this section as needed for your use case, XCodes will require your AppleID and password to install whichever version of XCode you specify.
-      "echo >> /Users/admin/.zprofile",
-      "echo 'eval \"$(/opt/homebrew/bin/brew shellenv\"' >> /Users/admin/.zprofile",
+      "echo >> /Users/${var.ssh_username}/.zprofile",
+      "echo 'eval \"$(/opt/homebrew/bin/brew shellenv\"' >> /Users/${var.ssh_username}/.zprofile",
       "eval \"$(/opt/homebrew/bin/brew shellenv)\"",
       "brew install fastlane",
       "brew install git",


### PR DESCRIPTION
this PR updates the provisioner install step for homebrew so that images build successfully and have the proper permissions to do so, removing said permissions after homebrew is installed.