### PR TITLE
Update Orka CRDs

### DIFF
--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	orkav1 "github.com/macstadium/packer-plugin-macstadium-orka/orkaapi/api/v1"
+	"github.com/macstadium/packer-plugin-macstadium-orka/orkaapi/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -139,7 +140,7 @@ func imageSaveOCI(ctx context.Context, state multistep.StateBag, config *Config)
 		return multistep.ActionHalt
 	}
 
-	reqModel := orkav1.OrkaVMPushRequestModel{ImageReference: config.ImageName}
+	reqModel := models.OrkaVMPushRequestModel{ImageReference: config.ImageName}
 	reqJSON, err := json.Marshal(reqModel)
 	if err != nil {
 		err := fmt.Errorf("failed to marshal VM Push request: %w", err)
@@ -194,7 +195,7 @@ func imageSaveOCI(ctx context.Context, state multistep.StateBag, config *Config)
 		return multistep.ActionHalt
 	}
 
-	var r orkav1.OrkaVMPushResponseModel
+	var r models.OrkaVMPushResponseModel
 	if err := json.Unmarshal(body, &r); err != nil {
 		err := fmt.Errorf("failed to unmarshal VM push response: %w", err)
 		state.Put("error", err)

--- a/orkaapi/api/v1/image_types.go
+++ b/orkaapi/api/v1/image_types.go
@@ -29,8 +29,10 @@ func init() {
 
 // ImageSpec describes the desired state of Image
 type ImageSpec struct {
-	// The size of the image file in formatted bytes
+	// The virtual size of the image file in formatted bytes
 	Size resource.Quantity `json:"size,omitempty"`
+	// The amount of storage the image file actually consumes in formatted bytes
+	SpaceUsed resource.Quantity `json:"spaceUsed,omitempty"`
 	// The user who initially created the image file represented by the Image
 	Owner string `json:"owner,omitempty"`
 	// The name of an Image, RemoteImage or VirtualMachineInstance to use as a source for a specific Image operation. Must match the SourceType
@@ -76,7 +78,9 @@ const (
 )
 
 //+kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.metadata.annotations['orka\.macstadium\.com/description']`
+//+kubebuilder:printcolumn:name="Image-Id",type=string,JSONPath=`.metadata.labels['orka\.macstadium\.com/image-id']`
 //+kubebuilder:printcolumn:name="Size",type=string,JSONPath=`.spec.size`
+//+kubebuilder:printcolumn:name="Space-Used",type=string,JSONPath=`.spec.spaceUsed`,priority=1
 //+kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.metadata.labels['kubernetes\.io/arch']`
 //+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 //+kubebuilder:printcolumn:name="Error",type=string,JSONPath=`.status.errorMessage`,priority=1

--- a/orkaapi/api/v1/orkanode_types.go
+++ b/orkaapi/api/v1/orkanode_types.go
@@ -22,6 +22,12 @@ import (
 
 // NOTE: JSON tags are required. When you add new fields, they must have JSON tags. Otherwise, they won't be serialized.
 
+// The image that should be cached on the node
+type OrkaImage struct {
+	// The name of the image to cache
+	Name string `json:"name"`
+}
+
 // OrkaNodeSpec describes the desired state of OrkaNode
 type OrkaNodeSpec struct {
 	// One or more tags setting node affinity. Node affinity indicates that the tagged OrkaNode is preferred for the deployment of VirtualMachineInstances with the same tag
@@ -44,8 +50,9 @@ const (
 type Architecture string
 
 const (
-	Amd64 Architecture = "amd64"
-	Arm   Architecture = "arm64"
+	Amd64   Architecture = "amd64"
+	Arm     Architecture = "arm64"
+	Unknown Architecture = "unknown"
 )
 
 // NodePhase is an enum providing information about the node status. Possible values are: Ready, Not Ready
@@ -54,6 +61,29 @@ type NodePhase string
 const (
 	NodeReady    NodePhase = "READY"
 	NodeNotReady NodePhase = "NOT READY"
+)
+
+// Describes a cached image on an OrkaNode
+type OrkaImageStatus struct {
+	// Names by which this image is known.
+	Names []string `json:"names,omitempty"`
+	// The virtual size of the image file in bytes
+	SizeBytes int64 `json:"size,omitempty"`
+	// The amount of storage the image file actually consumes in bytes
+	SpaceUsedBytes int64 `json:"spaceUsed,omitempty"`
+	// The status of the image. One of Ready, Caching, Failed
+	OrkaImageState OrkaImageState `json:"status,omitempty"`
+	// The error message if the image status is FAILED
+	ErrorMessage string `json:"errorMessage,omitempty"`
+}
+
+// OrkaImageState is an enum providing information about the image status. Possible values are: Ready, Caching, Failed
+type OrkaImageState string
+
+const (
+	OrkaImageStateReady   OrkaImageState = "Ready"
+	OrkaImageStateCaching OrkaImageState = "Caching"
+	OrkaImageStateFailed  OrkaImageState = "Failed"
 )
 
 // OrkaNodeStatus describes the observed state of OrkaNode
@@ -76,16 +106,27 @@ type OrkaNodeStatus struct {
 	NodeType NodeType `json:"nodeType"`
 	// The status of the OrkaNode. One of READY, NOT READY
 	Phase NodePhase `json:"phase"`
+	// The list of cached images on the OrkaNode
+	Images []OrkaImageStatus `json:"images,omitempty"`
+	// The version of the kubelet
+	KubeletVersion string `json:"kubeletVersion"`
+	// The version Container Runtime
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
+	// The MacOS Version
+	OSVersion string `json:"osVersion"`
 }
 
 //+kubebuilder:printcolumn:name="Available-CPU",type=integer,JSONPath=`.status.availableCpu`
 //+kubebuilder:printcolumn:name="Available-Memory",type=string,JSONPath=`.status.availableMemory`
-//+kubebuilder:printcolumn:name="Available-GPU",type=integer,JSONPath=`.status.availableGpu`,priority=1
+//+kubebuilder:printcolumn:name="Available-GPU",type=integer,JSONPath=`.status.availableGpu`,priority=2
 //+kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
 //+kubebuilder:printcolumn:name="IP",type=string,JSONPath=`.status.nodeIP`,priority=1
 //+kubebuilder:printcolumn:name="Allocatable-CPU",type=integer,JSONPath=`.status.allocatableCpu`,priority=1
 //+kubebuilder:printcolumn:name="Allocatable-Memory",type=string,JSONPath=`.status.allocatableMemory`,priority=1
-//+kubebuilder:printcolumn:name="Allocatable-GPU",type=integer,JSONPath=`.status.allocatableGpu`,priority=1
+//+kubebuilder:printcolumn:name="Allocatable-GPU",type=integer,JSONPath=`.status.allocatableGpu`,priority=2
+//+kubebuilder:printcolumn:name="Version",type=string,JSONPath=`.status.kubeletVersion`,priority=1
+//+kubebuilder:printcolumn:name="Runtime",type=string,JSONPath=`.status.containerRuntimeVersion`,priority=1
+//+kubebuilder:printcolumn:name="OS",type=string,JSONPath=`.status.osVersion`,priority=1
 //+kubebuilder:printcolumn:name="Architecture",type=string,JSONPath=`.metadata.labels['kubernetes\.io/arch']`,priority=1
 //+kubebuilder:printcolumn:name="Tags",type=string,JSONPath=`.spec.tags`,priority=1
 //+kubebuilder:object:root=true
@@ -118,12 +159,22 @@ func (left *OrkaNodeSpec) DeepEqual(right OrkaNodeSpec) bool {
 	rightTags := right.DeepCopy().Tags
 	sort.Strings(leftTags)
 	sort.Strings(rightTags)
-	return reflect.DeepEqual(leftTags, rightTags) &&
-		left.Namespace == right.Namespace
+
+	return reflect.DeepEqual(leftTags, rightTags) && left.Namespace == right.Namespace
 }
 
 // DeepEqual checks if two OrkaNodeStatus objects are equal
 func (left *OrkaNodeStatus) DeepEqual(right OrkaNodeStatus) bool {
+	leftImages := left.DeepCopy().Images
+	if leftImages == nil {
+		leftImages = []OrkaImageStatus{}
+	}
+
+	rightImages := right.DeepCopy().Images
+	if rightImages == nil {
+		rightImages = []OrkaImageStatus{}
+	}
+
 	return left.NodeIP == right.NodeIP &&
 		left.AllocatableCPU == right.AllocatableCPU &&
 		left.AllocatableMemory == right.AllocatableMemory &&
@@ -132,7 +183,11 @@ func (left *OrkaNodeStatus) DeepEqual(right OrkaNodeStatus) bool {
 		left.Phase == right.Phase &&
 		left.AvailableCPU == right.AvailableCPU &&
 		left.AvailableMemory == right.AvailableMemory &&
-		left.AvailableGPU == right.AvailableGPU
+		left.AvailableGPU == right.AvailableGPU &&
+		left.KubeletVersion == right.KubeletVersion &&
+		left.ContainerRuntimeVersion == right.ContainerRuntimeVersion &&
+		left.OSVersion == right.OSVersion &&
+		reflect.DeepEqual(leftImages, rightImages)
 }
 
 func (left *OrkaNode) DeepEqual(right *OrkaNode) bool {

--- a/orkaapi/api/v1/virtualmachineconfig_types.go
+++ b/orkaapi/api/v1/virtualmachineconfig_types.go
@@ -41,6 +41,8 @@ type VirtualMachineConfigSpec struct {
 	VNCConsole *bool `json:"vncConsole,omitempty"`
 	// Boolean setting if Network boost is enabled for VirtualMachineInstances created from the VirtualMachineConfig
 	NetBoost *bool `json:"netBoost,omitempty"`
+	// Boolean setting if legacy IO is enabled for VirtualMachineInstances created from the VirtualMachineConfig
+	LegacyIO *bool `json:"legacyIO,omitempty"`
 	// Boolean setting if GPU passthrough is enabled for VirtualMachineInstances created from the VirtualMachineConfig
 	GPUPassthrough *bool `json:"gpuPassthrough,omitempty"`
 	// +kubebuilder:validation:MinLength=8
@@ -58,6 +60,12 @@ type VirtualMachineConfigSpec struct {
 	Scheduler *string `json:"scheduler,omitempty"`
 	// The name of the node where you want the VirtualMachineInstance to run. If not specified, the VirtualMachineInstance will run on the first available node that matches the criteria (e.g., available CPU and memory, tags, groups, etc.)
 	NodeName *string `json:"nodeName,omitempty"`
+	// The width of the virtual display in pixels for VirtualMachineInstances created from the VirtualMachineConfig
+	DisplayWidth int `json:"displayWidth,omitempty"`
+	// The height of the virtual display in pixels for VirtualMachineInstances created from the VirtualMachineConfig
+	DisplayHeight int `json:"displayHeight,omitempty"`
+	// The DPI (dots per inch) of the virtual display for VirtualMachineInstances created from the VirtualMachineConfig
+	DisplayDPI int `json:"displayDPI,omitempty"`
 }
 
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`
@@ -68,10 +76,14 @@ type VirtualMachineConfigSpec struct {
 // +kubebuilder:printcolumn:name="Scheduler",type=string,JSONPath=`.spec.scheduler`,priority=1
 // +kubebuilder:printcolumn:name="Tag",type=string,JSONPath=`.spec.tag`,priority=1
 // +kubebuilder:printcolumn:name="Tag_Required",type=boolean,JSONPath=`.spec.tagRequired`,priority=1
+// +kubebuilder:printcolumn:name="Node_Name",type=string,JSONPath=`.spec.nodeName`,priority=1
 // +kubebuilder:printcolumn:name="GPU",type=boolean,JSONPath=`.spec.gpuPassthrough`,priority=1
 // +kubebuilder:printcolumn:name="Net_Boost",type=boolean,JSONPath=`.spec.netBoost`,priority=1
 // +kubebuilder:printcolumn:name="System_Serial",type=string,JSONPath=`.spec.systemSerial`,priority=1
 // +kubebuilder:printcolumn:name="Owner",type=string,JSONPath=`.metadata.annotations.orka\.macstadium\.com/created-by`,priority=1
+// +kubebuilder:printcolumn:name="Display_Width",type=integer,JSONPath=`.spec.displayWidth`,priority=1
+// +kubebuilder:printcolumn:name="Display_Height",type=integer,JSONPath=`.spec.displayHeight`,priority=1
+// +kubebuilder:printcolumn:name="Display_DPI",type=integer,JSONPath=`.spec.displayDPI`,priority=1
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=vmconfig;vmconfigs
 

--- a/orkaapi/api/v1/virtualmachineinstance_types.go
+++ b/orkaapi/api/v1/virtualmachineinstance_types.go
@@ -46,14 +46,20 @@ type VirtualMachineInstanceSpec struct {
 	VNCConsole *bool `json:"vncConsole,omitempty"`
 	// The scheduler handling the deployment. One of: default, most-allocated. When set to most-allocated, VirtualMachineInstances are scheduled to OrkaNodes having most of their resources allocated. The default setting keeps used vs free resources balanced between OrkaNodes
 	Scheduler *string `json:"scheduler,omitempty"`
-	// Boolean setting if legacy IO is enabled
-	LegacyIO *bool `json:"legacyIO,omitempty"`
 	// Boolean setting if Network boost is enabled
 	NetBoost *bool `json:"netBoost,omitempty"`
+	// Boolean setting if legacy IO is enabled
+	LegacyIO *bool `json:"legacyIO,omitempty"`
 	// Boolean setting if GPU passthrough is enabled. When enabled, VncConsole must be disabled
 	GPUPassthrough *bool `json:"gpuPassthrough,omitempty"`
 	// Memory in GiB. Rounded to the nearest 0.1 GiB. If not specified, the VirtualMachineInstance will use the default memory value set in the Orka configuration or will be automatically calculated based on the number of CPU cores
 	Memory *float64 `json:"memory,omitempty"`
+	// Width of virtual display for the virtual machine
+	DisplayWidth int `json:"displayWidth,omitempty"`
+	// Height of virtual display for the virtual machine
+	DisplayHeight int `json:"displayHeight,omitempty"`
+	// DPI of virtual display for the virtual machine
+	DisplayDPI int `json:"displayDPI,omitempty"`
 }
 
 // VMPhase is an enum providing information about the state of the VirtualMachineInstance deployment
@@ -77,6 +83,8 @@ type VirtualMachineInstanceStatus struct {
 	NodeName string `json:"nodeName"`
 	// The IP of the OrkaNode on which the VirtualMachineInstance is running
 	HostIP string `json:"hostIP"`
+	// The IP of the VirtualMachineInstance
+	IP string `json:"ip"`
 	// The SSH port assigned to the VirtualMachineInstance
 	SSHPort *int `json:"sshPort,omitempty"`
 	// The VNC port assigned to the VirtualMachineInstance
@@ -90,7 +98,7 @@ type VirtualMachineInstanceStatus struct {
 	ErrorMessage string `json:"errorMessage"`
 }
 
-//+kubebuilder:printcolumn:name="IP",type=string,JSONPath=`.status.hostIP`
+//+kubebuilder:printcolumn:name="IP",type=string,JSONPath=`.status.ip`
 //+kubebuilder:printcolumn:name="SSH",type=integer,JSONPath=`.status.sshPort`
 //+kubebuilder:printcolumn:name="VNC",type=integer,JSONPath=`.status.vncPort`
 //+kubebuilder:printcolumn:name="Screenshare",type=integer,JSONPath=`.status.screenSharePort`
@@ -100,10 +108,13 @@ type VirtualMachineInstanceStatus struct {
 //+kubebuilder:printcolumn:name="Memory",type=string,JSONPath=`.status.memory`,priority=1
 //+kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.status.nodeName`,priority=1
 //+kubebuilder:printcolumn:name="Architecture",type=string,JSONPath=`.metadata.labels['kubernetes\.io/arch']`,priority=1
-//+kubebuilder:printcolumn:name="Reserved-Ports",type=string,JSONPath=`.spec.reservedPorts`,priority=1
-//+kubebuilder:printcolumn:name="GPU-Passthrough",type=boolean,JSONPath=`.spec.gpuPassthrough`,priority=1
+//+kubebuilder:printcolumn:name="Reserved-Ports",type=string,JSONPath=`.spec.reservedPorts`,priority=2
+//+kubebuilder:printcolumn:name="GPU-Passthrough",type=boolean,JSONPath=`.spec.gpuPassthrough`,priority=2
 //+kubebuilder:printcolumn:name="Owner",type=string,JSONPath=`.metadata.annotations.orka\.macstadium\.com/created-by`,priority=1
 //+kubebuilder:printcolumn:name="Deploy-Date",type=string,JSONPath=`.metadata.creationTimestamp`,priority=1
+//+kubebuilder:printcolumn:name="Display-Width",type=integer,JSONPath=`.spec.displayWidth`,priority=2
+//+kubebuilder:printcolumn:name="Display-Height",type=integer,JSONPath=`.spec.displayHeight`,priority=2
+//+kubebuilder:printcolumn:name="Display-DPI",type=integer,JSONPath=`.spec.displayDPI`,priority=2
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:shortName=vm;vms
@@ -115,16 +126,6 @@ type VirtualMachineInstance struct {
 
 	Spec   VirtualMachineInstanceSpec   `json:"spec"`
 	Status VirtualMachineInstanceStatus `json:"status,omitempty"`
-}
-
-// OrkaVMPushRequestModel describes the expected JSON input data for the vm push operation.
-type OrkaVMPushRequestModel struct {
-	ImageReference string `json:"imageReference" binding:"required" example:"ghcr.io/organization-name/orka-images/base:latest"`
-}
-
-// OrkaVMPushResponseModel describes the JSON response data for the vm push operation.
-type OrkaVMPushResponseModel struct {
-	JobName string `json:"jobName"`
 }
 
 //+kubebuilder:object:root=true

--- a/orkaapi/models/virtualmachineinstance.go
+++ b/orkaapi/models/virtualmachineinstance.go
@@ -1,0 +1,11 @@
+package models
+
+// OrkaVMPushRequestModel describes the expected JSON input data for the vm push operation.
+type OrkaVMPushRequestModel struct {
+	ImageReference string `json:"imageReference" binding:"required" example:"ghcr.io/organization-name/orka-images/base:latest"`
+}
+
+// OrkaVMPushResponseModel describes the JSON response data for the vm push operation.
+type OrkaVMPushResponseModel struct {
+	JobName string `json:"jobName"`
+}


### PR DESCRIPTION
## Description

* Update Orka CRDs

These need to be kept up to date so we can use the latest features of Orka.
For example, the VM IP field is needed for bridge networking.

In addition, move the push model to a separate file as the ones under API just match the CRDs and should not contain anything else.

## Testing

1. Install the plugin
2. Build an image with Orka 3.4 and Orka 3.5 

