### PR TITLE
Add bridge networking support

### DIFF
--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -146,7 +146,11 @@ func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, 
 			vmi := event.Object.(*orkav1.VirtualMachineInstance)
 
 			if vmi.Status.Phase == orkav1.VMRunning {
-				return vmi.Status.HostIP, *vmi.Status.SSHPort, nil
+				ip := vmi.Status.IP
+				if ip == "" {
+					ip = vmi.Status.HostIP
+				}
+				return ip, *vmi.Status.SSHPort, nil
 			}
 
 			if vmi.Status.Phase == orkav1.VMFailed {


### PR DESCRIPTION
## Description

* Add bridge networking support

Since bridge networking is now supported, the plugin needs to use the VM IP field not the HostIP.
In addition, as the plugin could be used in older Orka versions that still do not have the VM IP field, we need to check if the IP is empty and use the HostIP if it is.
The ensures backwards compatibility.

## Testing

1. Install the plugin
3. Build an image with Orka 3.4, Orka 3.5 with NAT and bridge mode

