### PR TITLE
fix: Resolves issues with namespacing if the namespace has to be different than orka-default

### DIFF
--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -35,7 +35,7 @@ type OrkaClient interface {
 	Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
 	WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error)
-	WaitForImage(ctx context.Context, name string) error
+	WaitForImage(ctx context.Context, namespace, name string) error
 	WaitForPush(ctx context.Context, namespace, name string, timeout int) error
 }
 
@@ -161,15 +161,15 @@ func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, 
 	}
 }
 
-func (c *RealOrkaClient) WaitForImage(ctx context.Context, name string) error {
+func (c *RealOrkaClient) WaitForImage(ctx context.Context, namespace, name string) error {
 	return RetryOnWatcherErrorWithTimeout(ctx, 1*time.Hour, func(contextWithTimeout context.Context) error {
-		return c.waitForImage(contextWithTimeout, name)
+		return c.waitForImage(contextWithTimeout, namespace, name)
 	}, 1*time.Second)
 }
 
-func (c *RealOrkaClient) waitForImage(ctx context.Context, name string) error {
+func (c *RealOrkaClient) waitForImage(ctx context.Context, namespace, name string) error {
 	imageList := &orkav1.ImageList{}
-	watcher, err := c.Watch(ctx, imageList, client.InNamespace(DefaultOrkaNamespace), client.MatchingFields{"metadata.name": name})
+	watcher, err := c.Watch(ctx, imageList, client.InNamespace(namespace), client.MatchingFields{"metadata.name": name})
 	if err != nil {
 		return err
 	}

--- a/builder/orka/step_create_image.go
+++ b/builder/orka/step_create_image.go
@@ -54,7 +54,7 @@ func (s *stepCreateImage) Cleanup(state multistep.StateBag) {
 
 	image := &orkav1.Image{}
 
-	err := orkaClient.Get(context.Background(), client.ObjectKey{Namespace: DefaultOrkaNamespace, Name: config.ImageName}, image)
+	err := orkaClient.Get(context.Background(), client.ObjectKey{Namespace: config.OrkaVMBuilderNamespace, Name: config.ImageName}, image)
 	if err == nil && image.Status.State == orkav1.Failed {
 		ui.Say(fmt.Sprintf("Cleaning up image [%s]", config.ImageName))
 		if err := orkaClient.Delete(context.Background(), image); err != nil {
@@ -79,7 +79,7 @@ func imageSaveNFS(ctx context.Context, state multistep.StateBag, config *Config)
 
 	image := &orkav1.Image{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: DefaultOrkaNamespace,
+			Namespace: config.OrkaVMBuilderNamespace,
 			Name:      config.ImageName,
 			Annotations: map[string]string{
 				DescriptionAnnotationKey: config.ImageDescription,
@@ -109,7 +109,7 @@ func imageSaveNFS(ctx context.Context, state multistep.StateBag, config *Config)
 		return multistep.ActionHalt
 	}
 
-	if err := orkaClient.WaitForImage(ctx, config.ImageName); err != nil {
+	if err := orkaClient.WaitForImage(ctx, config.OrkaVMBuilderNamespace, config.ImageName); err != nil {
 		err := fmt.Errorf("failed to save the image: %w", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/mocks/orka_client_mock.go
+++ b/mocks/orka_client_mock.go
@@ -54,7 +54,7 @@ func (m OrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeo
 	return "1.2.3.4", 1234, nil
 }
 
-func (m OrkaClient) WaitForImage(ctx context.Context, name string) error {
+func (m OrkaClient) WaitForImage(ctx context.Context, namespace, name string) error {
 	if m.ErrorType == errorTypeWaitForImage {
 		return errors.New(m.ErrorType)
 	}


### PR DESCRIPTION
  Summary         
  - WaitForImage was hardcoded to use DefaultOrkaNamespace instead of the configured namespace, causing image saves to fail when the VM builder namespace differs from orka-default
  - Updated WaitForImage (interface, implementation, and mock) to accept a namespace parameter and pass it through to the underlying watcher
  - Fixed stepCreateImage cleanup and imageSaveNFS to use config.OrkaVMBuilderNamespace instead of the hardcoded DefaultOrkaNamespace

  Changes
  - builder/orka/orka_client.go: Added namespace parameter to WaitForImage interface and implementation; pass namespace to waitForImage instead of DefaultOrkaNamespace
  - builder/orka/step_create_image.go: Use config.OrkaVMBuilderNamespace in both image cleanup and imageSaveNFS creation/wait calls
  - mocks/orka_client_mock.go: Updated mock to match the updated WaitForImage interface signature
