### PR TITLE
feat(orka): add use_vm_ip option to connect via VM IP instead of node IP

### DIFF
--- a/builder/orka/config.go
+++ b/builder/orka/config.go
@@ -64,6 +64,12 @@ type Config struct {
 	// Required if Enable Orka IP Mapping is enabled. Map of Node Ips to the external IP values.
 	OrkaNodeIPMap map[string]string `mapstructure:"orka_node_ip_map"`
 
+	// When set to true, Packer will connect via SSH using the VM's own IP address
+	// instead of the Orka node IP. This is useful in environments (e.g. a MacStadium
+	// Kubernetes cluster using DHCP) where the node IP is not the correct address to
+	// reach the VM. Defaults to false.
+	UseVMIP bool `mapstructure:"use_vm_ip"`
+
 	// Configuration for VM launch timeout
 	PackerVMWaitTimeout int `mapstructure:"packer_vm_timeout"`
 

--- a/builder/orka/config.hcl2spec.go
+++ b/builder/orka/config.hcl2spec.go
@@ -86,6 +86,7 @@ type FlatConfig struct {
 	OrkaLegacyIO              *bool             `mapstructure:"orka_enable_legacy_io" cty:"orka_enable_legacy_io" hcl:"orka_enable_legacy_io"`
 	EnableOrkaNodeIPMapping   *bool             `mapstructure:"enable_orka_node_ip_mapping" cty:"enable_orka_node_ip_mapping" hcl:"enable_orka_node_ip_mapping"`
 	OrkaNodeIPMap             map[string]string `mapstructure:"orka_node_ip_map" cty:"orka_node_ip_map" hcl:"orka_node_ip_map"`
+	UseVMIP                   *bool             `mapstructure:"use_vm_ip" cty:"use_vm_ip" hcl:"use_vm_ip"`
 	PackerVMWaitTimeout       *int              `mapstructure:"packer_vm_timeout" cty:"packer_vm_timeout" hcl:"packer_vm_timeout"`
 	PackerPushTimeout         *int              `mapstructure:"packer_push_timeout" cty:"packer_push_timeout" hcl:"packer_push_timeout"`
 }
@@ -178,6 +179,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"orka_enable_legacy_io":        &hcldec.AttrSpec{Name: "orka_enable_legacy_io", Type: cty.Bool, Required: false},
 		"enable_orka_node_ip_mapping":  &hcldec.AttrSpec{Name: "enable_orka_node_ip_mapping", Type: cty.Bool, Required: false},
 		"orka_node_ip_map":             &hcldec.AttrSpec{Name: "orka_node_ip_map", Type: cty.Map(cty.String), Required: false},
+		"use_vm_ip":                    &hcldec.AttrSpec{Name: "use_vm_ip", Type: cty.Bool, Required: false},
 		"packer_vm_timeout":            &hcldec.AttrSpec{Name: "packer_vm_timeout", Type: cty.Number, Required: false},
 		"packer_push_timeout":          &hcldec.AttrSpec{Name: "packer_push_timeout", Type: cty.Number, Required: false},
 	}

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -146,15 +146,9 @@ func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, 
 			vmi := event.Object.(*orkav1.VirtualMachineInstance)
 
 			if vmi.Status.Phase == orkav1.VMRunning {
-				ip := vmi.Status.IP
-				if useVMIP {
-					// Force connecting to the VM's own IP (e.g. DHCP environments
-					// where the node IP is not the correct address to reach the VM).
-					if ip == "" {
-						return "", 0, fmt.Errorf("use_vm_ip is enabled but the VM does not report its own IP yet")
-					}
-				} else if ip == "" {
-					ip = vmi.Status.HostIP
+				ip, err := resolveVMIP(vmi, useVMIP)
+				if err != nil {
+					return "", 0, err
 				}
 				return ip, *vmi.Status.SSHPort, nil
 			}
@@ -165,6 +159,21 @@ func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, 
 			}
 		}
 	}
+}
+
+// resolveVMIP determines which IP Packer should use to reach the VM.
+// When useVMIP is true, the VM's own IP is required (useful in DHCP
+// environments where the node IP is not reachable). Otherwise it falls
+// back to the Orka node (host) IP when the VM IP is not set.
+func resolveVMIP(vmi *orkav1.VirtualMachineInstance, useVMIP bool) (string, error) {
+	ip := vmi.Status.IP
+	if ip != "" {
+		return ip, nil
+	}
+	if useVMIP {
+		return "", fmt.Errorf("use_vm_ip is enabled but the VM does not report its own IP yet")
+	}
+	return vmi.Status.HostIP, nil
 }
 
 func (c *RealOrkaClient) WaitForImage(ctx context.Context, name string) error {

--- a/builder/orka/orka_client.go
+++ b/builder/orka/orka_client.go
@@ -34,7 +34,7 @@ type OrkaClient interface {
 	Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
 	Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
-	WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error)
+	WaitForVm(ctx context.Context, namespace, name string, timeout int, useVMIP bool) (string, int, error)
 	WaitForImage(ctx context.Context, name string) error
 	WaitForPush(ctx context.Context, namespace, name string, timeout int) error
 }
@@ -114,18 +114,18 @@ func lookupIP(orkaEndpoint string) net.IP {
 	return ips[0]
 }
 
-func (c *RealOrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error) {
+func (c *RealOrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeout int, useVMIP bool) (string, int, error) {
 	var host string
 	var port int
 	err := RetryOnWatcherErrorWithTimeout(ctx, time.Duration(timeout)*time.Minute, func(contextWithTimeout context.Context) error {
 		var err error
-		host, port, err = c.waitForVm(contextWithTimeout, namespace, name, timeout)
+		host, port, err = c.waitForVm(contextWithTimeout, namespace, name, timeout, useVMIP)
 		return err
 	}, 1*time.Second)
 	return host, port, err
 }
 
-func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error) {
+func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, timeout int, useVMIP bool) (string, int, error) {
 	vmiList := &orkav1.VirtualMachineInstanceList{}
 	watcher, err := c.Watch(ctx, vmiList, client.InNamespace(namespace), client.MatchingFields{"metadata.name": name})
 	if err != nil {
@@ -147,7 +147,13 @@ func (c *RealOrkaClient) waitForVm(ctx context.Context, namespace, name string, 
 
 			if vmi.Status.Phase == orkav1.VMRunning {
 				ip := vmi.Status.IP
-				if ip == "" {
+				if useVMIP {
+					// Force connecting to the VM's own IP (e.g. DHCP environments
+					// where the node IP is not the correct address to reach the VM).
+					if ip == "" {
+						return "", 0, fmt.Errorf("use_vm_ip is enabled but the VM does not report its own IP yet")
+					}
+				} else if ip == "" {
 					ip = vmi.Status.HostIP
 				}
 				return ip, *vmi.Status.SSHPort, nil

--- a/builder/orka/step_create_vm.go
+++ b/builder/orka/step_create_vm.go
@@ -48,7 +48,7 @@ func (s *stepCreateVm) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionHalt
 	}
 
-	sshHost, sshPort, err := client.WaitForVm(ctx, config.OrkaVMBuilderNamespace, config.OrkaVMBuilderName, config.PackerVMWaitTimeout)
+	sshHost, sshPort, err := client.WaitForVm(ctx, config.OrkaVMBuilderNamespace, config.OrkaVMBuilderName, config.PackerVMWaitTimeout, config.UseVMIP)
 	if err != nil {
 		err := fmt.Errorf("failed to wait for the VM: %w", err)
 		state.Put("error", err)

--- a/docs/builders/config.mdx
+++ b/docs/builders/config.mdx
@@ -55,7 +55,7 @@ build {
 
 * `orka_endpoint` _(string)_ (optional): The Orka API endpoint to use
 
-* `orka_auth_token` _(string)_ **(required)**: The authentication token of the user. This must be a [service account token](https://support.macstadium.com/hc/en-us/articles/28333065069211-Orka-Cluster-Manage-Service-Accounts) and can be created following the instructions outlined in the linked supporting documentation. 
+* `orka_auth_token` _(string)_ **(required)**: The authentication token of the user. This must be a [service account token](https://support.macstadium.com/hc/en-us/articles/28333065069211-Orka-Cluster-Manage-Service-Accounts) and can be created following the instructions outlined in the linked supporting documentation.
 
 * `ssh_user` _(string)_ (optional): User on the virtual machine
 
@@ -73,7 +73,7 @@ build {
 
 * `orka_vm_tag` _(string)_ (optional): Image tag name for the builder VM
 
-* `packer_vm_timeout` _(int)_ (optional): Time packer will wait for a VM to finish launching in minutes. 
+* `packer_vm_timeout` _(int)_ (optional): Time packer will wait for a VM to finish launching in minutes.
 
 * `packer_push_timeout` _(int)_ (optional): Timeout in minutes packer will wait for image to push to an OCI registry. If the timeout is reached, the image will continue to push in the background. Default 60 minutes.
 
@@ -94,6 +94,8 @@ The following use cases do not need to be used in most scenarios.
 * `enable_orka_node_ip_mapping` _(bool)_ (optional): The plugin defaults to using the default node ips. If this option is set to true, the builder will use the passed in map under `orka_node_ip_map` to resolve ips.
 
 * `orka_node_ip_map` _(map[string]string)_ (optional): Required if `enable_orka_node_ip_mapping`. Map of Internal Node IPs to External Node Ips.
+
+* `use_vm_ip` _(bool)_ (optional): Defaults to `false`. When set to `true`, Packer connects via SSH using the VM's own IP address instead of the Orka node IP. This is useful in environments (e.g. a MacStadium Kubernetes cluster using DHCP) where the node IP is not the correct address to reach the VM and the build would otherwise fail to connect.
 
 # Information Notes / Gotchas
 

--- a/mocks/orka_client_mock.go
+++ b/mocks/orka_client_mock.go
@@ -46,7 +46,7 @@ func (m OrkaClient) Delete(ctx context.Context, obj client.Object, opts ...clien
 	return nil
 }
 
-func (m OrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeout int) (string, int, error) {
+func (m OrkaClient) WaitForVm(ctx context.Context, namespace, name string, timeout int, useVMIP bool) (string, int, error) {
 	if m.ErrorType == errorTypeWaitForVm {
 		return "", 0, errors.New(m.ErrorType)
 	}


### PR DESCRIPTION
Add a new boolean builder option `use_vm_ip` (default false). When enabled, Packer connects over SSH using the VM's own IP address instead of the Orka node (host) IP.

This fixes connection failures in MacStadium Kubernetes clusters that use DHCP, where the node IP is not the correct address to reach the VM and the build would otherwise fail to establish the SSH connection.

- Add UseVMIP config field with documentation (config.go)
- Thread useVMIP through WaitForVm/waitForVm; when true, always use vmi.Status.IP and keep retrying until the VM reports its IP, instead of falling back to vmi.Status.HostIP (orka_client.go)
- Update OrkaClient interface and mock signatures
- Pass config.UseVMIP from stepCreateVm (step_create_vm.go)
- Regenerate hcl2spec with use_vm_ip entry (config.hcl2spec.go)
- Document use_vm_ip option (docs/builders/config.mdx)